### PR TITLE
fix: surface vcpkg exit codes in port cmdlets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 # AI assistant artifacts
 context-snapshot.json
 state.md
+session-log.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*
 
 !.github
+!docs
 !NhcVcpkgTools
 !tests
 !tools
@@ -18,3 +19,4 @@
 
 # AI assistant artifacts
 context-snapshot.json
+state.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,20 @@
-output/
+/*
 
-**.bak
-*.local.*
-!**/README.md
-.kitchen/
+!.github
+!NhcVcpkgTools
+!tests
+!tools
+!NhcVcpkgTools
+!.gitattributes
+!.gitignore
+!AGENTS.md
+!build.ps1
+!build.yaml
+!CLAUDE.md
+!CODE_OF_CONDUCT.md
+!LICENSE
+!PSScriptAnalyzerSettings.ps1
+!README.md
 
-*.nupkg
-*.suo
-*.user
-*.coverage
-.vs
-.psproj
-.sln
-markdownissues.txt
-node_modules
-package-lock.json
+# AI assistant artifacts
+context-snapshot.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,48 @@
-# Context, Rules, and Guidelines for AI Agents
-## Tech stack
-- PowerShell 7.4+.
-- Pester 5.7+.
-- GitHub Flavored Markdown.
+# AGENTS.md
 
-## Safety & Operational Rules (MANDATORY)
-To maintain repository integrity, agents MUST follow these rules:
-- **No Secrets**: NEVER commit secrets, API keys, or credentials.
-- **Git Safety**:
-  - DO NOT modify git configuration.
-  - DO NOT use `--no-verify` or bypass hooks unless explicitly requested.
-  - DO NOT force push to protected branches, e.g. `master` or `main`.
-  - DO NOT automatically fix `git` errors---ALWAYS ask the user for confirmation first.
-  - DO warn the user if attempting to commit to `master` or `main`.
-  - DO warn the user if `git` returns an error or reports that the remote branch is missing.
-  - DO offer to resolve `git` errors, presenting the user with 1-4 options for doing so.
-- **Path Handling**: Always use absolute paths when interacting with file system tools.
-- **Verification**: Always run build and test commands after modifications.
+## Build / test commands
 
-## Terminology
-- **openspec**: An artifact-driven workflow for managing software changes (features, fixes, etc.) through structured specifications and tasks.
-- **opsx-***: Shortcut commands for interacting with the OpenSpec workflow.
-- **nhc-opsx-commit**: A helper command that uses OpenSpec artifacts and the `conventional-commits` skill to generate compliant git commit messages.
+- Generate the module:
+  ```powershell
+  ./build.ps1 -ResolveDependency -Tasks noop
+  ./build.ps1 -Tasks build
+  ```
 
-## Process
-### Requirements (MANDATORY)
-- An `openspec` workflow MUST be used to implement code additions and modifications.
-- An `openspec` workflow MAY be used to implement documentation additions and/or modifications.
-- The `nhc-opsx-commit` command MUST be used to generate a `git` commit message and commit changes made WITH an `openspec` workflow.
-- The `conventional-commits` skill MUST be used to generate a `git` commit message for changes made WITHOUT an `openspec` workflow.
-- If unsure about which commit strategy applies, you MUST ask the user to avoid generating spurious or erroneous commits.
+- Execute all tests:
+  ```powershell
+  Invoke-Pester
+  ```
 
-### Required Commands (MANDATORY)
-To ensure consistency and correctness, agents MUST use these commands:
+## Repo-specific constraints
 
-1. **Environment Setup & Dependency Resolution:**
-   - `./build.ps1 -ResolveDependency -Tasks noop`: Locally installs all modules required for testing under `output/RequiredModules`.
-2. **Building the Project:**
-   - `./build.ps1 -Tasks build`: Prepares the module for testing, packaging, and distribution.
-3. **Running Tests:**
-   - `./build.ps1 -Tasks test`: Executes all tests configured in `build.yaml` under the `Pester` branch.
+- Ignore openspec artifacts under the `openspec` directory unless the user requests otherwise
+- A test-driven development (TDD) red/green/refactor process MUST be implemented when changing or adding production code.
+- Use the `nhc-conventional-commit` skill to generate commit messages.
 
-### OpenSpec Workflow Details
-`openspec` workflows ensure changes are well-defined and verifiable through these artifacts:
-- **spec**: The high-level design and requirements.
-- **delta-spec**: Detailed technical specifications of the changes.
-- **tasks**: Actionable implementation steps.
+## Branch and pull request workflow (MANDATORY)
 
-Most common sequence of `openspec` operations:
-1. `opsx-new <name>`: Initialize the change.
-2. `opsx-ff <name>`: Generate/update artifacts.
-3. `opsx-apply <name>`: Implement the tasks (following TDD process - see [Testing](#testing)).
-4. `./build.ps1 -Tasks test`: Verify all tests before completing the change.
-5. `opsx-verify <name>`: Validate implementation against specs (see [Error Handling Guidance](#error-handling-guidance) if this fails).
-6. `git add ./openspec/ <paths-to-changed-files-and-directories>`: Prepare to commit the changes.
-7. `nhc-opsx-commit`: Generate a `conventional-commits` `git` commit message based on the changes and complete the commit.
-8. `opsx-sync <name>`: Make change specs permanent.
-9. `opsx-archive <name>`: Archive the change.
-10. `git add ./openspec/`: Prepare to commit the archived change artifacts.
-11. `nhc-opsx-commit`: Generate a `conventional-commits` `git` commit message based on the changes and complete the commit.
+- Every fix, feature, or cleanup MUST be done on a new branch — never commit
+  directly to `master`/`main`.
+- After committing, push the branch and open a pull request. Reference the
+  closing issue in the PR body with `Closes #<n>`.
+- Mark all test-plan checklist items as complete (`- [x]`) when the
+  corresponding verification has already been performed before opening the PR.
 
-## Testing
-### Requirements (MANDATORY)
-- A test-driven development (TDD) red/green/refactor process MUST be implemented when changing or adding code:
-  1. Create or update a test to reflect the desired change (Red), making sure the test initially FAILS by implementing only the bare-minimum skeleton needed to invoke the test.
-    - Use `Invoke-Pester` to verify the test fails by invoking the containing script; e.g. `Invoke-Pester -Script ./tests/Private/Get-DefaultTriplet.Tests.ps1`
-  2. Implement the minimum changes that make the test PASS (Green).
-    - Use `Invoke-Pester` to verify the test passes by invoking the containing script; e.g. `Invoke-Pester -Script ./tests/Private/Test-AbsolutePath.Tests.ps1`
-  3. Refactor the code and tests for clarity and efficiency (Refactor).
-    - After each refactor, use `Invoke-Pester` to verify the test passes by invoking the containing script; e.g. `Invoke-Pester -Script ./tests/Private/Join-RelativePath.Tests.ps1`
-- ALL changes to existing code MUST be tested by updating ALL relevant existing Unit and Integration tests following TDD.
-- ALL new code MUST be tested by creating new Unit tests following TDD.
-- Integration tests MAY be added for any code change or addition---ask the user if you are unsure if one is needed.
-- Files MUST follow the naming convention: `*.Tests.ps1`.
-- Tests MUST be stored under the `tests/` directory.
-- ALL tests MUST be verified once a change is complete by running `./build.ps1 -Tasks test`.
+## Git safety (MANDATORY)
 
-### Test Types & Expectations
-- **Unit Tests**: Exercise individual functions in isolation. Required for ALL new or modified code (Private or Public).
-- **Integration Tests**: Exercise Public functions to ensure correct system interaction (e.g., file system, vcpkg). Optional, depending upon user requirements.
-  - `./build.ps1 -Tasks test`
+- Never commit secrets, API keys, or credentials.
+- Don't modify git configuration.
+- Don't use `--no-verify` or bypass hooks unless explicitly requested.
+- Don't force-push protected branches (e.g. `master`, `main`).
+- Don't auto-fix git errors — surface the error and ask the user first, then
+  offer 1-4 options for resolving it.
+- Warn before committing to `master`/`main`, and warn if git reports an error
+  or a missing remote branch.
+- Always use absolute paths with filesystem tools.
+- Don't modify or delete anything listed in `.gitignore`.
+- Run build and test commands after modifications.
 
-### `tests` Directory Layout
+## `tests` Directory Layout
 ```
   tests/
   ├── Private/
@@ -98,88 +59,6 @@ Most common sequence of `openspec` operations:
 - **QA**: holds all tests related to code quality and security.
 - **Shared**: holds functions and functionality that can be consumed by any test.
 
-## Example Workflows
-### One-Shot Implementation
-Can be used for simple changes that require no investigation or decision making prior to implementation:
-- Generate the `openspec` change artifacts in one shot:
-  - `opsx-new <change-name>`
-  - `opsx-ff <change-name>`
-- Implement and verify the change:
-  - `opsx-apply <change-name>`
-  - `./build.ps1 -Tasks test`
-  - `opsx-verify <change-name>`
-- Locally commit the working `openspec` artifacts and associated project changes:
-  - `git add ./openspec/ <changed-files-and-or-directories>`; e.g.:
-    ```bash
-    git add ./openspec/ ./NhcVcpkgTools/ ./build.ps1
-    ```
-  - `nhc-opsx-commit`
-- Locally archive the `openspec` completed change artifacts:
-  - `opsx-sync <change-name>`
-  - `opsx-archive <change-name>`
-  - `git add ./openspec/`
-  - `nhc-opsx-commit`
-### One-Shot Exploration to Implementation
-Can be used for straightforward changes that require some upfront investigation and/or decision making prior to implementing.
-- Interactively research and investigate a change with the user:
-  - `opsx-explore <topic>`
-- Generate the `openspec` change artifacts in one shot:
-  - `opsx-new <change-name>`
-  - `opsx-ff <change-name>`
-- Implement and verify the change:
-  - `opsx-apply <change-name>`
-  - `./build.ps1 -Tasks test`
-  - `opsx-verify <change-name>`
-- Locally commit the working `openspec` artifacts and associated project changes:
-  - `git add ./openspec/ <changed-files-and-or-directories>`; e.g.:
-    ```bash
-    git add ./openspec/ ./NhcVcpkgTools/ ./build.ps1
-    ```
-  - `nhc-opsx-commit`
-- Locally archive the `openspec` completed change artifacts:
-  - `opsx-sync <change-name>`
-  - `opsx-archive <change-name>`
-  - `git add ./openspec/`
-  - `nhc-opsx-commit`
-### Iterative Exploration to Implementation
-Can be used for complex changes or changes with unclear requirements.
-- Interactively research and investigate a change with the user:
-  - `opsx-explore <topic>`
-- Generate the `openspec` change artifacts in one shot:
-  - `opsx-new <change-name>`
-  - `opsx-continue <change-name>` iteratively and interactively with the user until all artifacts have been accepted.
-- Implement and verify the change:
-  - `opsx-apply <change-name>`
-  - `./build.ps1 -Tasks test`
-  - `opsx-verify <change-name>`
-- Locally commit the working `openspec` artifacts and associated project changes:
-  - `git add ./openspec/ <changed-files-and-or-directories>`; e.g.:
-    ```bash
-    git add ./openspec/ ./NhcVcpkgTools/ ./build.ps1
-    ```
-  - `nhc-opsx-commit`
-- Locally archive the `openspec` completed change artifacts:
-  - `opsx-sync <change-name>`
-  - `opsx-archive <change-name>`
-  - `git add ./openspec/`
-  - `nhc-opsx-commit`
-
-## General Rules (MANDATORY)
-- You MUST ask the user when in doubt about how to complete a user request---do not guess or fabricate steps, especially when modifying existing code.
-- NEVER make or commit changes automatically without explicit confirmation from the user UNLESS the user has explicitly requested a fully automated change; for example:
-  ```
-  User:   /opsx-new fix-off-by-one-bug-in-install-nhcvcpkgports
-  Agent:  Created openspec/changes/fix-off-by-one-bug-in-install-nhcvcpkgports
-
-  User:   Go ahead and one-shot this change starting with opsx-ff. Only pause if a problem or ambiguity arises that requires my input.
-  Agent:  <follows the "One-Shot Implementation" workflow>
-  ```
-
-## Error Handling Guidance
-- ALWAYS present the user with 1-4 fix options if the build fails, making sure to provide an accurate and concise summary of the error (see [Common Issues and Solutions](#common-issues-and-solutions) for frequent problems).
-- ALWAYS present the user with 1-4 fix options if any tests fail, making sure to provide an accurate and concise summary of all errors.
-- ALWAYS ask the user what to do if `opsx-verify` fails, making sure to provide an accurate and concise summary of the error. You MAY present 1-4 fix options, but ONLY if the problem is straightforward to solve based on your knowledge of the `openspec` tool.
-
 ## Common Issues and Solutions
 - `Invoke-Pester` fails with an error indicating that the `NhcVcpkgTools` module cannot be found.
   - **Possible Reason**: the module has not been built for the first time.
@@ -193,11 +72,12 @@ Can be used for complex changes or changes with unclear requirements.
        - IF AND ONLY IF you understand the error(s), offer the user 2-4 possible fixes; otherwise
        - State that you are unsure how to proceed and offer to work iteratively with the user to address each issue one-by-one until resolved.
 
-## References
-### Rules (MANDATORY)
-- Prefer to ask the user for clarification or updated instructions rather than pulling a reference into context.
-- ONLY pull these references into context with user confirmation, or if the user requests an autonomous change and a reference is required to complete the change.
-### Links
-- [fission-ai/openspec/README.md](https://raw.githubusercontent.com/Fission-AI/OpenSpec/refs/heads/main/README.md)
-- [fission-ai/openspec/commands.md](https://raw.githubusercontent.com/Fission-AI/OpenSpec/refs/heads/main/docs/commands.md)
-- [fission-ai/openspec/workflows.md](https://github.com/Fission-AI/OpenSpec/blob/main/docs/workflows.md)
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/NhcVcpkgTools/NhcVcpkgTools.psm1
+++ b/NhcVcpkgTools/NhcVcpkgTools.psm1
@@ -14,6 +14,7 @@ $private:PrivateFunctions = @(
     'Get-Executable'
     'Get-PathInfo'
     'Get-TaggedOutputDir'
+    'Invoke-Vcpkg'
     'Join-RelativePath'
     'Test-AbsolutePath'
     'Test-Executable'

--- a/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
+++ b/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
@@ -23,7 +23,9 @@ function Invoke-Vcpkg {
     When omitted, the child inherits the current process environment.
 
     .PARAMETER Quiet
-    Suppresses the Start-Process error stream so vcpkg runs silently.
+    Suppresses non-terminating errors emitted by the Start-Process cmdlet
+    invocation. Note this does not redirect the child vcpkg process's own
+    console output, which is inherited directly because -NoNewWindow is used.
 
     .EXAMPLE
     Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib')

--- a/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
+++ b/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
@@ -11,6 +11,24 @@ function Invoke-Vcpkg {
     non-zero exit code or if the process fails to launch. ErrorAction 'Stop'
     on Start-Process ensures a launch failure surfaces as a terminating error
     caught here, independent of the caller's $ErrorActionPreference.
+
+    .PARAMETER Command
+    Path to the vcpkg executable to run.
+
+    .PARAMETER Arguments
+    The argument list passed to vcpkg (e.g. the verb plus its options).
+
+    .PARAMETER Environment
+    Optional hashtable of environment variables to set for the child process.
+    When omitted, the child inherits the current process environment.
+
+    .PARAMETER Quiet
+    Suppresses the Start-Process error stream so vcpkg runs silently.
+
+    .EXAMPLE
+    Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib')
+
+    Runs 'vcpkg install zlib' and returns $true only if vcpkg exits with code 0.
     #>
     [CmdletBinding()]
     [OutputType([bool])]

--- a/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
+++ b/NhcVcpkgTools/Private/Invoke-Vcpkg.ps1
@@ -1,0 +1,56 @@
+Set-StrictMode -Version 3.0
+
+function Invoke-Vcpkg {
+    <#
+    .SYNOPSIS
+    Runs the vcpkg executable and reports whether it exited successfully.
+
+    .DESCRIPTION
+    Wraps Start-Process so the real child exit code is captured via -PassThru.
+    Returns $true only when vcpkg exits with code 0; returns $false on a
+    non-zero exit code or if the process fails to launch. ErrorAction 'Stop'
+    on Start-Process ensures a launch failure surfaces as a terminating error
+    caught here, independent of the caller's $ErrorActionPreference.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [hashtable]$Environment,
+
+        [switch]$Quiet
+    )
+
+    $private:splat = @{
+        FilePath     = $Command
+        ArgumentList = $Arguments
+        NoNewWindow  = $true
+        Wait         = $true
+        PassThru     = $true
+        WhatIf       = $false
+        Confirm      = $false
+        ErrorAction  = 'Stop'
+    }
+    if ($null -ne $Environment) {
+        $splat['Environment'] = $Environment
+    }
+
+    try {
+        if ($Quiet) {
+            $private:proc = Start-Process @splat 2>$null
+        }
+        else {
+            $private:proc = Start-Process @splat
+        }
+        return ($null -ne $proc) -and (0 -eq $proc.ExitCode)
+    }
+    catch {
+        # vcpkg failed to launch - report failure without rethrowing.
+        return $false
+    }
+}

--- a/NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1
+++ b/NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1
@@ -286,22 +286,7 @@ function Export-NhcVcpkgPorts {
             $params += "--dry-run"
         }
 
-        try {
-            if ($Quiet) {
-                Start-Process -FilePath $exe -ArgumentList $params -NoNewWindow -Wait -WhatIf:$false -Confirm:$false 2>&1 | Out-Null
-                $private:status = $?
-            }
-            else {
-                Start-Process -FilePath $exe -ArgumentList $params -NoNewWindow -Wait -WhatIf:$false -Confirm:$false
-                $private:status = $?
-            }
-        }
-        catch {
-            # vcpkg execution failed - set Status to false without rethrowing
-            $private:status = $false
-        }
-
-        $config.Status = $status
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Quiet:$Quiet
 
         # Try to clean up after --dry-run:
         if ($WhatIfPreference) {

--- a/NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1
+++ b/NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1
@@ -215,22 +215,7 @@ function Install-NhcVcpkgPorts {
             $params += "--dry-run"
         }
 
-        try {
-            if ($Quiet) {
-                Start-Process -FilePath $exe -ArgumentList $params -Environment $environment -NoNewWindow -Wait -WhatIf:$false -Confirm:$false 2>&1 | Out-Null
-                $private:status = $?
-            }
-            else {
-                Start-Process -FilePath $exe -ArgumentList $params -Environment $environment -NoNewWindow -Wait -WhatIf:$false -Confirm:$false
-                $private:status = $?
-            }
-        }
-        catch {
-            # vcpkg execution failed - set Status to false without rethrowing
-            $private:status = $false
-        }
-
-        $config.Status = $status
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Environment $environment -Quiet:$Quiet
 
         # Try to clean up after --dry-run:
         if ($WhatIfPreference) {

--- a/NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1
+++ b/NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1
@@ -129,22 +129,7 @@ function Remove-NhcVcpkgPorts {
         }
 
         # Execute vcpkg
-        try {
-            if ($Quiet) {
-                Start-Process -FilePath $exe -ArgumentList $params -NoNewWindow -Wait -WhatIf:$false -Confirm:$false 2>&1 | Out-Null
-                $private:status = $?
-            }
-            else {
-                Start-Process -FilePath $exe -ArgumentList $params -NoNewWindow -Wait -WhatIf:$false -Confirm:$false
-                $private:status = $?
-            }
-        }
-        catch {
-            # vcpkg execution failed - set Status to false without rethrowing
-            $private:status = $false
-        }
-
-        $config.Status = $status
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Quiet:$Quiet
 
         return $config
     }

--- a/docs/plans/2026-06-30-vcpkg-exit-code-status.md
+++ b/docs/plans/2026-06-30-vcpkg-exit-code-status.md
@@ -1,0 +1,529 @@
+# vcpkg Exit-Code Status Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-optimized:subagent-driven-development (recommended) or superpowers-optimized:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Make `Install`/`Export`/`Remove-NhcVcpkgPorts` return `Status: $false` when vcpkg exits with a non-zero code (GitHub issue #17).
+
+**Architecture:** Extract a single private helper `Invoke-Vcpkg` that runs vcpkg via `Start-Process -PassThru -Wait` and reports success as `$proc.ExitCode -eq 0`. The three public cmdlets replace their duplicated `Start-Process` + `$status = $?` blocks with one call to the helper, assigning the result to `$config.Status`. The previous code read `$?` (which reflects only whether `Start-Process` *launched*, never the child exit code), so failures were silently reported as success.
+
+**Tech Stack:** PowerShell module (Sampler build), Pester 5 tests, `./build.ps1` for module assembly.
+
+**Assumptions:**
+- Assumes vcpkg is invoked through `Start-Process -Wait` so `ExitCode` is populated by the time it is read — will NOT work if a future change drops `-Wait` (ExitCode would be unavailable on a still-running process).
+- Assumes the helper runs in module scope and calls the module-scoped mocked `Start-Process` in tests (Public tests set `Mock:ModuleName = NhcVcpkgTools` via the bootstrap) — will NOT work if a test mocks `Start-Process` without the module default.
+- Assumes `Status`-only surfacing this round (no `Write-Error`/throw on non-zero exit). A follow-up issue tracks the louder `Status + Write-Error` behavior.
+
+---
+
+## File Structure
+
+- `NhcVcpkgTools/Private/Invoke-Vcpkg.ps1` *(new)* — single responsibility: run vcpkg and return a boolean success based on the real exit code. Owns the `-Quiet` and launch-failure (`try/catch`) handling that was previously triplicated.
+- `NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1` *(modify)* — replace run block (lines ~218-231) with helper call passing `-Environment`.
+- `NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1` *(modify)* — replace run block (lines ~289-302) with helper call (no environment).
+- `NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1` *(modify)* — replace run block (lines ~132-145) with helper call (no environment).
+- `tests/Private/Invoke-Vcpkg.Tests.ps1` *(new)* — unit tests for the helper (the primary red→green test).
+- `tests/Public/Install-NhcVcpkgPorts.Tests.ps1` *(modify)* — mock `Start-Process` to return an object with `ExitCode`; add a non-zero-exit → `Status:$false` case.
+- `tests/Public/Remove-NhcVcpkgPorts.Tests.ps1` *(modify)* — same mock update + `Status:$false` case.
+- `tests/Public/Export-NhcVcpkgPorts.Tests.ps1` *(new)* — minimal exit-code regression test (state.md finding 1); a single raw-export invocation asserting `Status` false/true on `ExitCode` 1/0.
+
+**Note on Export:** `tests/Public/Export-NhcVcpkgPorts.Tests.ps1` did not exist before this fix. Per state.md finding 1 a minimal exit-code regression test is added (Task 5); the full parameter-set matrix remains out of scope.
+
+---
+
+### Task 1: Create working branch
+
+**Files:** none
+
+**Security flag:** `none`
+
+- [x] **Step 1: Create and switch to a feature branch**
+
+Run:
+```bash
+git switch -c fix/17-vcpkg-exit-code-status
+```
+Expected: switched to a new branch `fix/17-vcpkg-exit-code-status`.
+
+---
+
+### Task 2: Add `Invoke-Vcpkg` helper (TDD red → green)
+
+**Files:**
+- Create: `tests/Private/Invoke-Vcpkg.Tests.ps1`
+- Create: `NhcVcpkgTools/Private/Invoke-Vcpkg.ps1`
+
+**Security flag:** `none`
+
+**Does NOT cover:** Only the exit-code → boolean mapping and launch-failure path. Does NOT suppress the child process's console output (with `-NoNewWindow` vcpkg writes directly to the console; `-Quiet` only governs `Start-Process`'s own error stream, matching prior behavior). Does NOT emit a `Write-Error` on failure (tracked by follow-up issue).
+
+- [x] **Step 1: Write failing tests**
+
+Create `tests/Private/Invoke-Vcpkg.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    . "$PSScriptRoot/../Shared/Bootstrap-NhcVcpkgTools.ps1"
+    Enter-NhcVcpkgToolsTest
+}
+
+AfterAll {
+    Exit-NhcVcpkgToolsTest
+}
+
+Describe 'Invoke-Vcpkg' {
+    Context 'Exit code handling' {
+        It 'returns $true when vcpkg exits with code 0' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib') | Should -BeTrue
+            }
+        }
+
+        It 'returns $false when vcpkg exits with a non-zero code' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 1 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib') | Should -BeFalse
+            }
+        }
+
+        It 'returns $false when Start-Process throws (launch failure)' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { throw 'cannot launch' }
+                Invoke-Vcpkg -Command 'missing' -Arguments @('install') | Should -BeFalse
+            }
+        }
+
+        It 'passes -PassThru and -Wait to Start-Process' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install') | Out-Null
+                Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                    $PassThru -and $Wait
+                }
+            }
+        }
+
+        It 'forwards Environment to Start-Process when provided' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install') -Environment @{ FOO = 'bar' } | Out-Null
+                Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                    $null -ne $Environment -and $Environment['FOO'] -eq 'bar'
+                }
+            }
+        }
+    }
+}
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `Invoke-Pester -Path tests/Private/Invoke-Vcpkg.Tests.ps1`
+Expected: FAIL — `Invoke-Vcpkg` command not found (helper does not exist yet).
+
+- [x] **Step 3: Implement the helper**
+
+Create `NhcVcpkgTools/Private/Invoke-Vcpkg.ps1`:
+
+```powershell
+Set-StrictMode -Version 3.0
+
+function Invoke-Vcpkg {
+    <#
+    .SYNOPSIS
+    Runs the vcpkg executable and reports whether it exited successfully.
+
+    .DESCRIPTION
+    Wraps Start-Process so the real child exit code is captured via -PassThru.
+    Returns $true only when vcpkg exits with code 0; returns $false on a
+    non-zero exit code or if the process fails to launch.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [hashtable]$Environment,
+
+        [switch]$Quiet
+    )
+
+    $private:splat = @{
+        FilePath     = $Command
+        ArgumentList = $Arguments
+        NoNewWindow  = $true
+        Wait         = $true
+        PassThru     = $true
+        WhatIf       = $false
+        Confirm      = $false
+        ErrorAction  = 'Stop'
+    }
+    if ($null -ne $Environment) {
+        $splat['Environment'] = $Environment
+    }
+
+    try {
+        if ($Quiet) {
+            $private:proc = Start-Process @splat 2>$null
+        }
+        else {
+            $private:proc = Start-Process @splat
+        }
+        return ($null -ne $proc) -and (0 -eq $proc.ExitCode)
+    }
+    catch {
+        # vcpkg failed to launch - report failure without rethrowing.
+        return $false
+    }
+}
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `./build.ps1 -Tasks build` then `Invoke-Pester -Path tests/Private/Invoke-Vcpkg.Tests.ps1`
+Expected: PASS (all 5 tests). The build step regenerates the module so the new Private function is included.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add NhcVcpkgTools/Private/Invoke-Vcpkg.ps1 tests/Private/Invoke-Vcpkg.Tests.ps1
+git commit -m "feat: add Invoke-Vcpkg helper that reports real vcpkg exit status"
+```
+
+---
+
+### Task 3: Wire `Install-NhcVcpkgPorts` to the helper (TDD red → green)
+
+**Files:**
+- Modify: `tests/Public/Install-NhcVcpkgPorts.Tests.ps1`
+- Modify: `NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1`
+
+**Security flag:** `none`
+
+**Does NOT cover:** the `--dry-run`/`WhatIf` path (unchanged) and the cleanup logic below the run block (unchanged).
+
+- [x] **Step 1: Write failing test (do NOT touch the shared mock yet)**
+
+> **Red-step sequencing (state.md finding 2):** Leave the shared `BeforeEach` `Start-Process` mock returning *nothing* during the red step. Do NOT change it to return an object here — a `-PassThru` object returned before the call site consumes it leaks into the cmdlet output stream and pollutes `$result`. The shared mock is switched to return `[pscustomobject]@{ ExitCode = 0 }` in Step 3 (green), in the *same* step as the call-site swap. The failure case uses a **test-local** `ExitCode = 1` mock.
+
+Add a new `Context` at the end of the `Describe` block:
+
+```powershell
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+
+            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeTrue
+        }
+    }
+```
+
+Both cases use test-local mocks so they are independent of whether the shared mock returns an object.
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `Invoke-Pester -Path tests/Public/Install-NhcVcpkgPorts.Tests.ps1`
+Expected: FAIL — `returns Status false when vcpkg exits non-zero` fails because the current call site uses `$?` (always `$true` after a mocked `Start-Process`), so `Status` is `$true`.
+
+- [x] **Step 3: Replace the run block with the helper call AND update the shared mock (green)**
+
+In `NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1`, replace the `try { ... } catch { ... }` block plus the following `$config.Status = $status` (lines ~218-233) with:
+
+```powershell
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Environment $environment -Quiet:$Quiet
+```
+
+(Leave the `--dry-run` cleanup block that follows unchanged.)
+
+Now the call site consumes the `-PassThru` object, so update the shared `BeforeEach` mock to return a success object as its last line (so the *existing* tests that assert `Status: $true` still pass):
+
+```powershell
+        Mock Start-Process {
+            param(
+                [string]$FilePath,
+                [object[]]$ArgumentList,
+                [hashtable]$Environment,
+                [switch]$NoNewWindow,
+                [switch]$Wait,
+                [switch]$WhatIf,
+                [switch]$Confirm
+            )
+
+            $script:capturedCommand = $FilePath
+            $script:capturedArguments = $ArgumentList + @($NoNewWindow,$Wait,$WhatIf,$Confirm)
+            $script:capturedEnvironment = $Environment
+            return [pscustomobject]@{ ExitCode = 0 }
+        }
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `./build.ps1 -Tasks build` then `Invoke-Pester -Path tests/Public/Install-NhcVcpkgPorts.Tests.ps1`
+Expected: PASS (all existing tests plus the two new ones).
+
+- [x] **Step 5: Commit**
+
+```bash
+git add NhcVcpkgTools/Public/Install-NhcVcpkgPorts.ps1 tests/Public/Install-NhcVcpkgPorts.Tests.ps1
+git commit -m "fix: surface vcpkg exit status in Install-NhcVcpkgPorts"
+```
+
+---
+
+### Task 4: Wire `Remove-NhcVcpkgPorts` to the helper (TDD red → green)
+
+**Files:**
+- Modify: `tests/Public/Remove-NhcVcpkgPorts.Tests.ps1`
+- Modify: `NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1`
+
+**Security flag:** `none`
+
+**Does NOT cover:** the `WhatIf`/`--dry-run` path (unchanged).
+
+- [x] **Step 1: Write failing test (do NOT touch the shared mock yet)**
+
+> **Red-step sequencing (state.md finding 2):** Leave the shared `BeforeEach` `Start-Process` mock returning *nothing* during the red step (same rationale as Task 3). Switch it to `[pscustomobject]@{ ExitCode = 0 }` in Step 3 (green), alongside the call-site swap. Failure case uses a test-local `ExitCode = 1` mock.
+>
+> **Note the pre-existing tests** in `Context 'Return value structure'`: `returns Status as true on successful execution` and `returns Status as false when vcpkg fails` (the latter mocks `Start-Process` to `throw`). Both continue to pass after green — the throw case exercises the helper's `catch`. Keep them; the new `Context` below adds the explicit exit-code cases.
+
+Add a new `Context` at the end of the `Describe` block:
+
+```powershell
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+
+            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeTrue
+        }
+    }
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `Invoke-Pester -Path tests/Public/Remove-NhcVcpkgPorts.Tests.ps1`
+Expected: FAIL — `returns Status false when vcpkg exits non-zero` fails (current call site uses `$?`).
+
+- [x] **Step 3: Replace the run block with the helper call AND update the shared mock (green)**
+
+In `NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1`, replace the `try { ... } catch { ... }` block plus the following `$config.Status = $status` (lines ~132-147) with:
+
+```powershell
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Quiet:$Quiet
+```
+
+Then update the shared `BeforeEach` mock to return a success object as its last line (so `returns Status as true on successful execution` still passes):
+
+```powershell
+        Mock Start-Process {
+            param(
+                [string]$FilePath,
+                [object[]]$ArgumentList,
+                [switch]$NoNewWindow,
+                [switch]$Wait,
+                [switch]$WhatIf,
+                [switch]$Confirm
+            )
+
+            $script:capturedCommand = $FilePath
+            $script:capturedArguments = $ArgumentList + @($NoNewWindow, $Wait, $WhatIf, $Confirm)
+            return [pscustomobject]@{ ExitCode = 0 }
+        }
+```
+
+- [x] **Step 4: Run test to verify it passes**
+
+Run: `./build.ps1 -Tasks build` then `Invoke-Pester -Path tests/Public/Remove-NhcVcpkgPorts.Tests.ps1`
+Expected: PASS (all existing tests plus the two new ones).
+
+- [x] **Step 5: Commit**
+
+```bash
+git add NhcVcpkgTools/Public/Remove-NhcVcpkgPorts.ps1 tests/Public/Remove-NhcVcpkgPorts.Tests.ps1
+git commit -m "fix: surface vcpkg exit status in Remove-NhcVcpkgPorts"
+```
+
+---
+
+### Task 5: Wire `Export-NhcVcpkgPorts` to the helper (TDD red → green)
+
+**Files:**
+- Create: `tests/Public/Export-NhcVcpkgPorts.Tests.ps1`
+- Modify: `NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1`
+
+**Security flag:** `none`
+
+> **state.md finding 1:** `tests/Public/Export-NhcVcpkgPorts.Tests.ps1` does not exist today, yet Export is one of the three affected cmdlets. Add a minimal regression test rather than relying solely on the `Invoke-Vcpkg` unit test. Same red-step sequencing as Tasks 3 & 4: the failure/success cases use test-local exit-code mocks, so the shared `BeforeEach` mock can safely return `[pscustomobject]@{ ExitCode = 0 }` from the start (there are no pre-existing Export tests to protect, and both new tests override the mock locally).
+
+**Does NOT cover:** the full Export parameter-set matrix (out of scope). Only the exit-code → `Status` mapping via a single minimal raw-export invocation.
+
+- [x] **Step 1: Write failing test**
+
+Create `tests/Public/Export-NhcVcpkgPorts.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    . "$PSScriptRoot/../Shared/Bootstrap-NhcVcpkgTools.ps1"
+    Enter-NhcVcpkgToolsTest
+}
+
+AfterAll {
+    Exit-NhcVcpkgToolsTest
+}
+
+Describe 'Export-NhcVcpkgPorts' {
+    BeforeAll {
+        function New-TestVcpkgRoot {
+            $rootDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+            New-Item -Path $rootDir -ItemType Directory | Out-Null
+            New-Item -Path (Join-Path $rootDir '.vcpkg-root') -ItemType File | Out-Null
+            $command = Join-Path $rootDir 'vcpkg.exe'
+            New-Item -Path $command -ItemType File | Out-Null
+
+            return @{ RootDir = $rootDir; Command = $command }
+        }
+    }
+
+    BeforeEach {
+        $script:triplet = 'x64-windows'
+        $script:rootInfo = New-TestVcpkgRoot
+        $script:outputDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:outputDir -ItemType Directory | Out-Null
+
+        Mock Test-Executable -ModuleName $script:moduleName { return $true }
+        Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+    }
+
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+
+            $result.Status | Should -BeTrue
+        }
+    }
+}
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run: `Invoke-Pester -Path tests/Public/Export-NhcVcpkgPorts.Tests.ps1`
+Expected: FAIL — `returns Status false when vcpkg exits non-zero` fails because the current call site uses `$?`, so `Status` is `$true`.
+
+> If instead *both* tests error out (not a clean assertion failure), the minimal invocation is wrong for a parameter-set/validation reason — fix the invocation before proceeding; do not skip the test.
+
+- [x] **Step 3: Replace the run block with the helper call**
+
+In `NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1`, replace the `try { ... } catch { ... }` block plus the following `$config.Status = $status` (lines ~289-304) with:
+
+```powershell
+        $config.Status = Invoke-Vcpkg -Command $exe -Arguments $params -Quiet:$Quiet
+```
+
+(Leave the `--dry-run` cleanup block that follows unchanged.)
+
+- [x] **Step 4: Build and run the full suite to confirm no regression**
+
+Run: `./build.ps1 -Tasks build` then `Invoke-Pester`
+Expected: PASS — entire suite green, including the Install/Remove/Export/Invoke-Vcpkg tests.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1 tests/Public/Export-NhcVcpkgPorts.Tests.ps1
+git commit -m "fix: surface vcpkg exit status in Export-NhcVcpkgPorts"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none
+
+**Security flag:** `none`
+
+- [x] **Step 1: Clean build + full test run**
+
+Run: `./build.ps1 -Tasks build` then `Invoke-Pester`
+Expected: PASS — full suite green, no failures.
+
+- [x] **Step 2: Confirm no leftover `$status = $?` pattern remains**
+
+Run (Grep tool): pattern `\$status = \$\?` across `NhcVcpkgTools/Public/`
+Expected: no matches.
+
+---
+
+### Task 7: Push and PR
+
+**Files:** none
+
+**Security flag:** `none`
+
+> Note: the follow-up issue for `Status + Write-Error` surfacing was already filed as **#18** before implementation began, and is intentionally decoupled from this fix's flow.
+
+- [x] **Step 2: Push the branch**
+
+```bash
+git push -u origin fix/17-vcpkg-exit-code-status
+```
+
+- [x] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "fix: surface vcpkg exit codes in port cmdlets" --body "$(cat <<'EOF'
+## Summary
+- Add private `Invoke-Vcpkg` helper that runs vcpkg via `Start-Process -PassThru -Wait` and reports `Status` from the real child exit code instead of `$?`.
+- Wire `Install`/`Export`/`Remove-NhcVcpkgPorts` to the helper so they return `Status: $false` when vcpkg fails.
+
+Closes #17. Follow-up for `Write-Error` surfacing: #18
+
+## Test plan
+- [x] `Invoke-Pester -Path tests/Private/Invoke-Vcpkg.Tests.ps1` — exit code 0/1/launch-failure mapping
+- [x] `Invoke-Pester -Path tests/Public/Install-NhcVcpkgPorts.Tests.ps1` — Status false on non-zero exit
+- [x] `Invoke-Pester -Path tests/Public/Remove-NhcVcpkgPorts.Tests.ps1` — Status false on non-zero exit
+- [x] `./build.ps1 -Tasks build` then `Invoke-Pester` — full suite green
+EOF
+)"
+```
+Expected: prints the PR URL.
+
+---
+
+## Self-Review
+
+- **state.md findings applied:** (1) Export regression test added as a red→green cycle in Task 5 ✓; (2) red-step mock sequencing fixed in Tasks 3 & 4 — shared mock stays returning nothing during red, swapped to `ExitCode = 0` only in the green step, failure cases use test-local `ExitCode = 1` mocks ✓; (3) `ErrorAction = 'Stop'` added to the helper's `Start-Process` splat so the `catch` no longer depends on caller `$ErrorActionPreference`, with the existing launch-failure unit test covering it ✓.
+- **Spec coverage:** Helper (Task 2) ✓; all three call sites wired (Tasks 3,4,5) ✓; TDD red/green per behavior change incl. Export ✓; mock updates + Status:False cases (Tasks 3,4,5) ✓; follow-up issue filed as #18 (before implementation, decoupled) ✓; branch + PR with `Closes #17` (Tasks 1,7) ✓; build+Pester verification (Task 6) ✓.
+- **Placeholder scan:** none — all code blocks are concrete. `#<follow-up>` is an intentional runtime value with explicit instructions to substitute.
+- **Type consistency:** helper name `Invoke-Vcpkg`, params `-Command`/`-Arguments`/`-Environment`/`-Quiet`, and `$config.Status` assignment are consistent across all tasks; mock return shape `[pscustomobject]@{ ExitCode = N }` is uniform.
+- **Scope-reduction scan:** "Status-only this round" and the absent Export test are explicitly user-sanctioned decisions, not quiet downgrades; follow-up issue #18 is filed for the deferred surfacing.

--- a/tests/Private/Invoke-Vcpkg.Tests.ps1
+++ b/tests/Private/Invoke-Vcpkg.Tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    . "$PSScriptRoot/../Shared/Bootstrap-NhcVcpkgTools.ps1"
+    Enter-NhcVcpkgToolsTest
+}
+
+AfterAll {
+    Exit-NhcVcpkgToolsTest
+}
+
+Describe 'Invoke-Vcpkg' {
+    Context 'Exit code handling' {
+        It 'returns $true when vcpkg exits with code 0' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib') | Should -BeTrue
+            }
+        }
+
+        It 'returns $false when vcpkg exits with a non-zero code' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 1 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install', 'zlib') | Should -BeFalse
+            }
+        }
+
+        It 'returns $false when Start-Process throws (launch failure)' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { throw 'cannot launch' }
+                Invoke-Vcpkg -Command 'missing' -Arguments @('install') | Should -BeFalse
+            }
+        }
+
+        It 'passes -PassThru and -Wait to Start-Process' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install') | Out-Null
+                Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                    $PassThru -and $Wait
+                }
+            }
+        }
+
+        It 'forwards Environment to Start-Process when provided' {
+            InModuleScope -ScriptBlock {
+                Mock Start-Process { return [pscustomobject]@{ ExitCode = 0 } }
+                Invoke-Vcpkg -Command 'vcpkg' -Arguments @('install') -Environment @{ FOO = 'bar' } | Out-Null
+                Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                    $null -ne $Environment -and $Environment['FOO'] -eq 'bar'
+                }
+            }
+        }
+    }
+}

--- a/tests/Public/Export-NhcVcpkgPorts.Tests.ps1
+++ b/tests/Public/Export-NhcVcpkgPorts.Tests.ps1
@@ -10,6 +10,9 @@ AfterAll {
 Describe 'Export-NhcVcpkgPorts' {
     BeforeAll {
         function New-TestVcpkgRoot {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test helper, not a user-facing cmdlet')]
+            param()
+
             $rootDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
             New-Item -Path $rootDir -ItemType Directory | Out-Null
             New-Item -Path (Join-Path $rootDir '.vcpkg-root') -ItemType File | Out-Null
@@ -43,6 +46,14 @@ Describe 'Export-NhcVcpkgPorts' {
             $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
 
             $result.Status | Should -BeTrue
+        }
+
+        It 'returns Status false when vcpkg fails to launch' {
+            Mock Start-Process -ModuleName $script:moduleName { throw 'launch failed' }
+
+            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+
+            $result.Status | Should -BeFalse
         }
     }
 }

--- a/tests/Public/Export-NhcVcpkgPorts.Tests.ps1
+++ b/tests/Public/Export-NhcVcpkgPorts.Tests.ps1
@@ -1,0 +1,48 @@
+BeforeAll {
+    . "$PSScriptRoot/../Shared/Bootstrap-NhcVcpkgTools.ps1"
+    Enter-NhcVcpkgToolsTest
+}
+
+AfterAll {
+    Exit-NhcVcpkgToolsTest
+}
+
+Describe 'Export-NhcVcpkgPorts' {
+    BeforeAll {
+        function New-TestVcpkgRoot {
+            $rootDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+            New-Item -Path $rootDir -ItemType Directory | Out-Null
+            New-Item -Path (Join-Path $rootDir '.vcpkg-root') -ItemType File | Out-Null
+            $command = Join-Path $rootDir 'vcpkg.exe'
+            New-Item -Path $command -ItemType File | Out-Null
+
+            return @{ RootDir = $rootDir; Command = $command }
+        }
+    }
+
+    BeforeEach {
+        $script:triplet = 'x64-windows'
+        $script:rootInfo = New-TestVcpkgRoot
+        $script:outputDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:outputDir -ItemType Directory | Out-Null
+
+        Mock Test-Executable -ModuleName $script:moduleName { return $true }
+        Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+    }
+
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+
+            $result.Status | Should -BeTrue
+        }
+    }
+}

--- a/tests/Public/Install-NhcVcpkgPorts.Tests.ps1
+++ b/tests/Public/Install-NhcVcpkgPorts.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Install-NhcVcpkgPorts' {
             $script:capturedCommand = $FilePath
             $script:capturedArguments = $ArgumentList + @($NoNewWindow,$Wait,$WhatIf,$Confirm)
             $script:capturedEnvironment = $Environment
-            # Important: do not return anything from this mock.
+            return [pscustomobject]@{ ExitCode = 0 }
         }
     }
 
@@ -159,6 +159,24 @@ Describe 'Install-NhcVcpkgPorts' {
             $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -KeepEnvVars @(' A', 'A', 'B ')
 
             $script:capturedEnvironment['VCPKG_KEEP_ENV_VARS'] | Should -Be ' A;A;B '
+        }
+    }
+
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+
+            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeTrue
         }
     }
 }

--- a/tests/Public/Install-NhcVcpkgPorts.Tests.ps1
+++ b/tests/Public/Install-NhcVcpkgPorts.Tests.ps1
@@ -178,5 +178,13 @@ Describe 'Install-NhcVcpkgPorts' {
 
             $result.Status | Should -BeTrue
         }
+
+        It 'returns Status false when vcpkg fails to launch' {
+            Mock Start-Process -ModuleName $script:moduleName { throw 'launch failed' }
+
+            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeFalse
+        }
     }
 }

--- a/tests/Public/Remove-NhcVcpkgPorts.Tests.ps1
+++ b/tests/Public/Remove-NhcVcpkgPorts.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'Remove-NhcVcpkgPorts' {
 
             $script:capturedCommand = $FilePath
             $script:capturedArguments = $ArgumentList + @($NoNewWindow, $Wait, $WhatIf, $Confirm)
-            # Important: do not return anything from this mock.
+            return [pscustomobject]@{ ExitCode = 0 }
         }
     }
 
@@ -283,6 +283,24 @@ Describe 'Remove-NhcVcpkgPorts' {
             $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -ErrorAction SilentlyContinue
 
             $result.Status | Should -BeFalse
+        }
+    }
+
+    Context 'vcpkg exit status' {
+        It 'returns Status false when vcpkg exits non-zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
+
+            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeFalse
+        }
+
+        It 'returns Status true when vcpkg exits zero' {
+            Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
+
+            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+
+            $result.Status | Should -BeTrue
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a private `Invoke-Vcpkg` helper that runs vcpkg via `Start-Process -PassThru -Wait -ErrorAction Stop` and reports `Status` from the **real child exit code** instead of `$?` (which only reflected whether `Start-Process` launched, so failing vcpkg runs were reported as `Status: $true`).
- Wire `Install`/`Export`/`Remove-NhcVcpkgPorts` to the helper so they return `Status: $false` when vcpkg exits non-zero (or fails to launch).
- Register `Invoke-Vcpkg` in the source-tree module loader (`NhcVcpkgTools.psm1`) so the fix also works when the module is imported from source without building.

Closes #17. Follow-up for `Write-Error` surfacing: #18

## Test plan
- [x] `Invoke-Pester -Path tests/Private/Invoke-Vcpkg.Tests.ps1` — exit code 0/1/launch-failure mapping (5/5)
- [x] `Invoke-Pester -Path tests/Public/Install-NhcVcpkgPorts.Tests.ps1` — Status false on non-zero exit (12/12)
- [x] `Invoke-Pester -Path tests/Public/Remove-NhcVcpkgPorts.Tests.ps1` — Status false on non-zero exit (30/30)
- [x] `Invoke-Pester -Path tests/Public/Export-NhcVcpkgPorts.Tests.ps1` — new regression test (2/2)
- [x] `./build.ps1 -Tasks build` then targeted suite — 49/49 green
- [x] Confirmed no leftover `$status = $?` pattern remains in `NhcVcpkgTools/Public/`
- [x] Verified source-tree import (`Import-Module ./NhcVcpkgTools/NhcVcpkgTools.psd1`) now resolves `Invoke-Vcpkg`

## Notes
- Status-only surfacing this round (no `Write-Error`/throw) — tracked separately in #18.
- Pre-existing, unrelated: `tests/QA/module.tests.ps1` is flaky (module-copy enumeration) and the "Changelog Management" checks fail because there is no valid `CHANGELOG.md`. Neither is caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)