### PR TITLE
refactor: clear PSScriptAnalyzer warnings across module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,13 @@
   ./build.ps1 -Tasks build
   ```
 
-- Execute all tests:
+- Execute all tests (canonical — builds the module and sets `PSModulePath`
+  so the QA tests under `tests/QA` are discovered, matching CI):
   ```powershell
-  Invoke-Pester
+  ./build.ps1 -Tasks test
   ```
+  A bare `Invoke-Pester` runs the unit tests but fails QA discovery unless
+  the module has already been built and is on `PSModulePath`.
 
 ## Repo-specific constraints
 

--- a/NhcVcpkgTools/NhcVcpkgTools.psd1
+++ b/NhcVcpkgTools/NhcVcpkgTools.psd1
@@ -10,13 +10,17 @@
     Description          = 'Tools for working with vcpkg from PowerShell.'
     PowerShellVersion    = '7.4'
     RequiredModules      = @()
-    AliasesToExport      = @()
-    CmdletsToExport      = @()
-    DscResourcesToExport = @()
-    FunctionsToExport    = @(
+    AliasesToExport      = @(
         'Export-NhcVcpkgPorts'
         'Install-NhcVcpkgPorts'
         'Remove-NhcVcpkgPorts'
+    )
+    CmdletsToExport      = @()
+    DscResourcesToExport = @()
+    FunctionsToExport    = @(
+        'Export-NhcVcpkgPort'
+        'Install-NhcVcpkgPort'
+        'Remove-NhcVcpkgPort'
     )
 
     VariablesToExport    = @(

--- a/NhcVcpkgTools/NhcVcpkgTools.psm1
+++ b/NhcVcpkgTools/NhcVcpkgTools.psm1
@@ -9,7 +9,7 @@ $private:Root = $PSScriptRoot
 $private:PrivateFunctions = @(
     'ConvertTo-NormalizedPath'
     'Get-BinaryType'
-    'Get-CommonArguments'
+    'Get-CommonArgument'
     'Get-DefaultTriplet'
     'Get-Executable'
     'Get-PathInfo'
@@ -24,13 +24,21 @@ $private:PrivateFunctions = @(
 )
 
 $private:PublicFunctions = @(
-    'Export-NhcVcpkgPorts'
-    'Install-NhcVcpkgPorts'
-    'Remove-NhcVcpkgPorts'
+    'Export-NhcVcpkgPort'
+    'Install-NhcVcpkgPort'
+    'Remove-NhcVcpkgPort'
 )
 
 $private:PublicVariables = @(
     'g_NhcVcpkgValidExportFormats'
+)
+
+# Legacy plural aliases retained for backward compatibility. The Set-Alias
+# statements live in the corresponding Public function files.
+$private:PublicAliases = @(
+    'Export-NhcVcpkgPorts'
+    'Install-NhcVcpkgPorts'
+    'Remove-NhcVcpkgPorts'
 )
 
 $PrivateFunctions | ForEach-Object {
@@ -46,3 +54,4 @@ $PublicFunctions | ForEach-Object {
 # Only export public functions:
 Export-ModuleMember -Function $PublicFunctions
 Export-ModuleMember -Variable $PublicVariables
+Export-ModuleMember -Alias $PublicAliases

--- a/NhcVcpkgTools/Private/Get-CommonArgument.ps1
+++ b/NhcVcpkgTools/Private/Get-CommonArgument.ps1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version 3.0
 
-function Get-CommonArguments {
+function Get-CommonArgument {
     <#
     .SYNOPSIS
     Generate an array of common vcpkg command line arguments.
@@ -265,7 +265,7 @@ function Get-CommonArguments {
             $result += @{
                 BuildDir = @{
                     Path   = "$BuildDir"
-                    Exists = (Test-Path -Path $BuildDir -PathType Container) 
+                    Exists = (Test-Path -Path $BuildDir -PathType Container)
                 }
             }
         }
@@ -276,8 +276,8 @@ function Get-CommonArguments {
             $result += @{
                 PackageDir = @{
                     Path   = "$PackageDir"
-                    Exists = (Test-Path -Path $PackageDir -PathType Container) 
-                } 
+                    Exists = (Test-Path -Path $PackageDir -PathType Container)
+                }
             }
         }
 
@@ -288,8 +288,8 @@ function Get-CommonArguments {
             $result += @{
                 InstallDir = @{
                     Path   = "$InstallDir"
-                    Exists = (Test-Path -Path $InstallDir -PathType Container) 
-                } 
+                    Exists = (Test-Path -Path $InstallDir -PathType Container)
+                }
             }
         }
 

--- a/NhcVcpkgTools/Private/Get-PathInfo.ps1
+++ b/NhcVcpkgTools/Private/Get-PathInfo.ps1
@@ -19,6 +19,7 @@ function Get-PathInfo {
     #>
 
     [CmdletBinding()]
+    [OutputType([System.IO.FileSystemInfo], [System.IO.FileInfo])]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [string]$Path,

--- a/NhcVcpkgTools/Private/Get-TaggedOutputDir.ps1
+++ b/NhcVcpkgTools/Private/Get-TaggedOutputDir.ps1
@@ -33,6 +33,7 @@ function Get-TaggedOutputDir {
     #>
 
     [CmdletBinding()]
+    [OutputType([hashtable])]
     param (
         [AllowEmptyString()]
         [string]$OutputDir,

--- a/NhcVcpkgTools/Public/Export-NhcVcpkgPort.ps1
+++ b/NhcVcpkgTools/Public/Export-NhcVcpkgPort.ps1
@@ -3,7 +3,7 @@ Set-StrictMode -Version 3.0
 # Valid export formats. This is exported from the module so that it can be accessed from ArgumentCompleter:
 $g_NhcVcpkgValidExportFormats = @( "zip", "7zip", "nuget" )
 
-function Export-NhcVcpkgPorts {
+function Export-NhcVcpkgPort {
     <#
     .SYNOPSIS
     Exports installed vcpkg ports.
@@ -65,37 +65,37 @@ function Export-NhcVcpkgPorts {
     Specifies the path to the installed ports. The path must exist, and defaults to '<vcpkg-root>/installed'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -All -Format zip -Tag ''
+    Export-NhcVcpkgPort -All -Format zip -Tag ''
 
     Exports all installed ports from '<vcpkg-root>/installed' to './<yyyyMMdd-hhmmss>/vcpkg-export.zip'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports fmt -Format zip -Output 'fmt-release'
+    Export-NhcVcpkgPort -Ports fmt -Format zip -Output 'fmt-release'
 
     Export 'fmt' from '<vcpkg-root>/installed' to './fmt-release.zip'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports boost-filesystem,fmt -Format 7zip -Triplet x64-linux
+    Export-NhcVcpkgPort -Ports boost-filesystem,fmt -Format 7zip -Triplet x64-linux
 
     Exports only 'boost-filesystem' and 'fmt' ports from '<vcpkg-root>'/installed for the x64-linux triplet to './vcpkg-export.7z'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports zlib -Raw -InstallDir '/vcpkg-data/installed' -OutputDir '.' -Tag ''
+    Export-NhcVcpkgPort -Ports zlib -Raw -InstallDir '/vcpkg-data/installed' -OutputDir '.' -Tag ''
 
     Raw export of 'zlib' from '/vcpkg-data/installed' to './<yyyyMMdd-hhmmss>/...' using the default root for version control.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports zlib -Raw -RootDir '/vcpkg-root' -OutputDir '.' -Tag ''
+    Export-NhcVcpkgPort -Ports zlib -Raw -RootDir '/vcpkg-root' -OutputDir '.' -Tag ''
 
     Raw export of 'zlib' from '/vcpkg-root/installed' to './<yyyyMMdd-hhmmss>/...'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports zlib -Format 7zip -RootDir '/vcpkg-root' -OutputDir '.' -Output 'zlib-current' -Tag ''
+    Export-NhcVcpkgPort -Ports zlib -Format 7zip -RootDir '/vcpkg-root' -OutputDir '.' -Output 'zlib-current' -Tag ''
 
     Export 'zlib' from '/vcpkg-root/installed' to './<yyyyMMdd-hhmmss>/zlib-current.7z'.
 
     .EXAMPLE
-    Export-NhcVcpkgPorts -Ports zlib -Format zip -Vcpkg '/vcpkg-root/vcpkg' -RootDir '/vcpkg-root' -Tag ''
+    Export-NhcVcpkgPort -Ports zlib -Format zip -Vcpkg '/vcpkg-root/vcpkg' -RootDir '/vcpkg-root' -Tag ''
 
     Export 'zlib' from '/vcpkg-root/installed' to './export/<yyyyMMdd-hhmmss>/vcpkg-export.zip'.
 
@@ -117,6 +117,8 @@ function Export-NhcVcpkgPorts {
     #>
 
     [CmdletBinding(SupportsShouldProcess = $true)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'The WhatIf preview must always reach the console; Write-Information is silent by default.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'ArgumentCompleter uses a fixed positional signature; unused positions are intentional.')]
     param (
         [Parameter(ParameterSetName = "PortsRaw", Mandatory = $true, Position = 0)]
         [Parameter(ParameterSetName = "PortsFile", Mandatory = $true, Position = 0)]
@@ -241,7 +243,7 @@ function Export-NhcVcpkgPorts {
 
         # Build the common vcpkg arguments list:
         $PSBoundParameters.OutputDir = $tagged.OutputDir.Path
-        $config += Get-CommonArguments -Parameters $PSBoundParameters -Directories $required
+        $config += Get-CommonArgument -Parameters $PSBoundParameters -Directories $required
 
         $private:exe = $config.Command
         $private:verb = 'export'
@@ -322,3 +324,5 @@ function Export-NhcVcpkgPorts {
         return $config
     }
 }
+
+Set-Alias -Name Export-NhcVcpkgPorts -Value Export-NhcVcpkgPort

--- a/NhcVcpkgTools/Public/Install-NhcVcpkgPort.ps1
+++ b/NhcVcpkgTools/Public/Install-NhcVcpkgPort.ps1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version 3.0
 
-function Install-NhcVcpkgPorts {
+function Install-NhcVcpkgPort {
     <#
     .SYNOPSIS
     Build and install the requested vcpkg ports.
@@ -74,22 +74,22 @@ function Install-NhcVcpkgPorts {
     Enforces exact version usage for build tools from the manifest file. Corresponds to the vcpkg flag '--x-abi-tools-use-exact-versions'.
 
     .EXAMPLE
-    Install-NhcVcpkgPorts -All -Tag ''
+    Install-NhcVcpkgPort -All -Tag ''
 
     Builds and installs all ports defined by the default manifest file to './build/<yyyyMMdd-HHmmss>' for the default target triplet.
 
     .EXAMPLE
-    Install-NhcVcpkgPorts -All -Tag 1.0.0 -ManifestDir './config'
+    Install-NhcVcpkgPort -All -Tag 1.0.0 -ManifestDir './config'
 
     Builds and installs all ports defined by './config/vcpkg.json' to './build/<yyyyMMdd-HHmmss>' for the default target triplet.
 
     .EXAMPLE
-    Install-NhcVcpkgPorts -Ports zlib -OutputDir 'c:/vcpkg-release' -Triplet x64-windows-static
+    Install-NhcVcpkgPort -Ports zlib -OutputDir 'c:/vcpkg-release' -Triplet x64-windows-static
 
     Builds and installs zlib and its dependencies to 'c:/vcpkg-release' for the x64-windows-static triplet.
 
     .EXAMPLE
-    Install-NhcVcpkgPorts -All -RootDir '/vcpkg/2025-07-25' -OutputDir '/vcpkg-releases/2025-07-25' -Triplet x64-linux
+    Install-NhcVcpkgPort -All -RootDir '/vcpkg/2025-07-25' -OutputDir '/vcpkg-releases/2025-07-25' -Triplet x64-linux
 
     Builds and installs all ports defined by the default manifest to '/vcpkg-releases/2025-07-25' for the x64-linux triplet.
 
@@ -114,6 +114,7 @@ function Install-NhcVcpkgPorts {
     #>
 
     [CmdletBinding(DefaultParameterSetName = "Ports", SupportsShouldProcess = $true)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'The WhatIf preview must always reach the console; Write-Information is silent by default.')]
     param (
         [Parameter(ParameterSetName = "Ports", Mandatory = $true, Position = 0)]
         [string[]]$Ports,
@@ -179,7 +180,7 @@ function Install-NhcVcpkgPorts {
         # Build the common vcpkg arguments list:
         $tagged.OutputDir ??= @{ Path = ''; Exists = $false }
         # Note: OutputDir must be passed as ParentDir so required directories (above) are created under either the default <vcpkg-root> or the caller-defined output directory.
-        $config += Get-CommonArguments -Parameters $PSBoundParameters -Directories $required -ParentDir $tagged.OutputDir.Path
+        $config += Get-CommonArgument -Parameters $PSBoundParameters -Directories $required -ParentDir $tagged.OutputDir.Path
 
         $private:exe = $config.Command
         $private:verb = 'install'
@@ -251,3 +252,5 @@ function Install-NhcVcpkgPorts {
         return $config
     }
 }
+
+Set-Alias -Name Install-NhcVcpkgPorts -Value Install-NhcVcpkgPort

--- a/NhcVcpkgTools/Public/Remove-NhcVcpkgPort.ps1
+++ b/NhcVcpkgTools/Public/Remove-NhcVcpkgPort.ps1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version 3.0
 
-function Remove-NhcVcpkgPorts {
+function Remove-NhcVcpkgPort {
     <#
     .SYNOPSIS
     Removes installed vcpkg ports.
@@ -43,19 +43,20 @@ function Remove-NhcVcpkgPorts {
     Suppresses confirmation prompts unless -Confirm is explicitly specified.
 
     .EXAMPLE
-    Remove-NhcVcpkgPorts -Ports 'zlib', 'fmt'
+    Remove-NhcVcpkgPort -Ports 'zlib', 'fmt'
     Removes the specified ports.
 
     .EXAMPLE
-    Remove-NhcVcpkgPorts -Outdated
+    Remove-NhcVcpkgPort -Outdated
     Removes all outdated ports.
 
     .EXAMPLE
-    Remove-NhcVcpkgPorts -Ports 'zlib' -Recurse -WhatIf
+    Remove-NhcVcpkgPort -Ports 'zlib' -Recurse -WhatIf
     Shows what would be removed including dependencies without actually removing.
     #>
     [CmdletBinding(DefaultParameterSetName = 'Ports', SupportsShouldProcess = $true)]
     [OutputType([hashtable])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'The WhatIf preview must always reach the console; Write-Information is silent by default.')]
     param(
         [Parameter(ParameterSetName = 'Ports')]
         [ValidateNotNullOrEmpty()]
@@ -108,7 +109,7 @@ function Remove-NhcVcpkgPorts {
 
         # Build the common vcpkg arguments list:
         $private:config = @{}
-        $config += Get-CommonArguments -Parameters $PSBoundParameters -Directories $required
+        $config += Get-CommonArgument -Parameters $PSBoundParameters -Directories $required
 
         $private:exe = $config.Command
         $private:verb = 'remove'
@@ -134,3 +135,5 @@ function Remove-NhcVcpkgPorts {
         return $config
     }
 }
+
+Set-Alias -Name Remove-NhcVcpkgPorts -Value Remove-NhcVcpkgPort

--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ This module uses [Pester](https://pester.dev/) v5+ for unit testing. To run test
     ```powershell
     Install-Module Pester -Force
     ```
-2.  Run all tests from the module root:
+2.  Run the full suite the way CI does — this builds the module and puts it
+    on `PSModulePath` so the QA tests under `tests/QA` are discovered:
     ```powershell
-    Invoke-Pester -Path tests
+    ./build.ps1 -Tasks test
     ```
+    For a fast inner loop on unit tests, `Invoke-Pester -Path tests` also
+    works, but the module must already be built (`./build.ps1 -Tasks build`);
+    otherwise the QA tests in `tests/QA` fail discovery because the built
+    module is not on `PSModulePath`.
 
 ## Running Lint
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following functions are exported by this module:
 
 *   `Install-NhcVcpkgPort`: Installs one or more vcpkg ports.
 *   `Export-NhcVcpkgPort`: Exports installed vcpkg ports to a specified format.
+*   `Remove-NhcVcpkgPort`: Removes installed or outdated vcpkg ports.
 
 ## Installation
 
@@ -41,10 +42,10 @@ This function installs one or more vcpkg ports for a specified triplet.
 
 ```powershell
 # Example: Install the 'fmt' port for the default triplet
-Install-NhcVcpkgPort -PortName "fmt"
+Install-NhcVcpkgPort -Ports "fmt"
 
 # Example: Install multiple ports for a specific triplet
-Install-NhcVcpkgPort -PortName "fmt", "gtest" -Triplet "x64-windows-static"
+Install-NhcVcpkgPort -Ports "fmt", "gtest" -Triplet "x64-windows-static"
 ```
 
 ### Export-NhcVcpkgPort
@@ -53,10 +54,22 @@ This function exports all installed vcpkg ports to a specified format, such as z
 
 ```powershell
 # Example: Export all installed ports to a zip file
-Export-NhcVcpkgPort -Format zip
+Export-NhcVcpkgPort -All -Format zip
 
 # Example: Export all installed ports to a 7z file in a specific directory
-Export-NhcVcpkgPort -Format 7zip -OutputDir "C:\vcpkg_exports"
+Export-NhcVcpkgPort -All -Format 7zip -OutputDir "C:\vcpkg_exports"
+```
+
+### Remove-NhcVcpkgPort
+
+This function removes installed or outdated vcpkg ports.
+
+```powershell
+# Example: Remove specific ports
+Remove-NhcVcpkgPort -Ports "zlib", "fmt"
+
+# Example: Remove all outdated ports
+Remove-NhcVcpkgPort -Outdated
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This module simplifies common vcpkg tasks by providing a set of functions to man
 
 The following functions are exported by this module:
 
-*   `Install-NhcVcpkgPorts`: Installs one or more vcpkg ports.
-*   `Export-NhcVcpkgPorts`: Exports installed vcpkg ports to a specified format.
+*   `Install-NhcVcpkgPort`: Installs one or more vcpkg ports.
+*   `Export-NhcVcpkgPort`: Exports installed vcpkg ports to a specified format.
 
 ## Installation
 
@@ -35,28 +35,28 @@ Import-Module ./NhcVcpkgTools
 
 ## Usage
 
-### Install-NhcVcpkgPorts
+### Install-NhcVcpkgPort
 
 This function installs one or more vcpkg ports for a specified triplet.
 
 ```powershell
 # Example: Install the 'fmt' port for the default triplet
-Install-NhcVcpkgPorts -PortName "fmt"
+Install-NhcVcpkgPort -PortName "fmt"
 
 # Example: Install multiple ports for a specific triplet
-Install-NhcVcpkgPorts -PortName "fmt", "gtest" -Triplet "x64-windows-static"
+Install-NhcVcpkgPort -PortName "fmt", "gtest" -Triplet "x64-windows-static"
 ```
 
-### Export-NhcVcpkgPorts
+### Export-NhcVcpkgPort
 
 This function exports all installed vcpkg ports to a specified format, such as zip or 7zip.
 
 ```powershell
 # Example: Export all installed ports to a zip file
-Export-NhcVcpkgPorts -Format zip
+Export-NhcVcpkgPort -Format zip
 
 # Example: Export all installed ports to a 7z file in a specific directory
-Export-NhcVcpkgPorts -Format 7zip -OutputDir "C:\vcpkg_exports"
+Export-NhcVcpkgPort -Format 7zip -OutputDir "C:\vcpkg_exports"
 ```
 
 ## Running Tests

--- a/tests/Private/Get-CommonArgument.Tests.ps1
+++ b/tests/Private/Get-CommonArgument.Tests.ps1
@@ -7,7 +7,7 @@ AfterAll {
     Exit-NhcVcpkgToolsTest
 }
 
-Describe 'Get-CommonArguments' {
+Describe 'Get-CommonArgument' {
     BeforeEach {
         Mock Test-VcpkgRoot { return $true }
         Mock Test-Executable { return $true }
@@ -20,7 +20,7 @@ Describe 'Get-CommonArguments' {
         It 'should throw an error if Command is invalid' {
             InModuleScope -ScriptBlock {
                 $params = @{ Command = 'invalid-exe' }
-                { Get-CommonArguments -Parameters $params } | Should -Throw
+                { Get-CommonArgument -Parameters $params } | Should -Throw
             }
         }
 
@@ -30,7 +30,7 @@ Describe 'Get-CommonArguments' {
                 $exePath = Join-Path -Path $rootDir -ChildPath 'vcpkg.exe'
                 Mock Get-Executable { return $exePath }
                 $params = @{ RootDir = $rootDir; Command = $exePath }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.RootDir | Should -Be $rootDir
                 $result.Command | Should -Be $exePath
             }
@@ -39,7 +39,7 @@ Describe 'Get-CommonArguments' {
         It 'should include classic mode when Ports key is present' {
             InModuleScope -ScriptBlock {
                 $params = @{ Ports = 'zlib'; RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Contain '--classic'
             }
         }
@@ -47,7 +47,7 @@ Describe 'Get-CommonArguments' {
         It 'should include feature flags when All key is present' {
             InModuleScope -ScriptBlock {
                 $params = @{ All = $true; RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Where-Object { $_ -like '*manifest*' } | Should -Not -BeNullOrEmpty
             }
         }
@@ -67,7 +67,7 @@ Describe 'Get-CommonArguments' {
                 $expectedBuildDir = Join-Path -Path $rootDir -ChildPath 'custombuildtrees'
                 $expectedPackageDir = Join-Path -Path $rootDir -ChildPath 'custompackages'
                 $expectedInstallDir = Join-Path -Path $rootDir -ChildPath 'custominstalled'
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Contain "--downloads-root=`"$expectedDownloadDir`""
                 $result.Arguments | Should -Contain "--x-buildtrees-root=`"$expectedBuildDir`""
                 $result.Arguments | Should -Contain "--x-packages-root=`"$expectedPackageDir`""
@@ -80,7 +80,7 @@ Describe 'Get-CommonArguments' {
         It 'should include --outdated flag when Outdated key is present and truthy' {
             InModuleScope -ScriptBlock {
                 $params = @{ Outdated = $true; RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Contain '--outdated'
             }
         }
@@ -88,7 +88,7 @@ Describe 'Get-CommonArguments' {
         It 'should NOT include --outdated flag when Outdated key is not present' {
             InModuleScope -ScriptBlock {
                 $params = @{ RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Not -Contain '--outdated'
             }
         }
@@ -98,7 +98,7 @@ Describe 'Get-CommonArguments' {
         It 'should include --recurse flag when Recurse key is present and truthy' {
             InModuleScope -ScriptBlock {
                 $params = @{ Recurse = $true; RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Contain '--recurse'
             }
         }
@@ -106,7 +106,7 @@ Describe 'Get-CommonArguments' {
         It 'should NOT include --recurse flag when Recurse key is not present' {
             InModuleScope -ScriptBlock {
                 $params = @{ RootDir = (Get-Location).ProviderPath; Command = 'vcpkg.exe' }
-                $result = Get-CommonArguments -Parameters $params
+                $result = Get-CommonArgument -Parameters $params
                 $result.Arguments | Should -Not -Contain '--recurse'
             }
         }
@@ -120,12 +120,12 @@ Describe 'Get-CommonArguments' {
                     RootDir = $rootDir
                     Command = 'vcpkg.exe'
                 }
-                $result = Get-CommonArguments -Parameters $params
-                
+                $result = Get-CommonArgument -Parameters $params
+
                 # Verify Command and RootDir are strings
                 $result.Command | Should -BeOfType [string]
                 $result.RootDir | Should -BeOfType [string]
-                
+
                 # Verify all directory Path values are strings
                 $result.ParentDir.Path | Should -BeOfType [string]
                 $result.DownloadDir.Path | Should -BeOfType [string]

--- a/tests/Public/Aliases.Tests.ps1
+++ b/tests/Public/Aliases.Tests.ps1
@@ -1,0 +1,29 @@
+BeforeAll {
+    . "$PSScriptRoot/../Shared/Bootstrap-NhcVcpkgTools.ps1"
+    Enter-NhcVcpkgToolsTest
+}
+
+AfterAll {
+    Exit-NhcVcpkgToolsTest
+}
+
+Describe 'Public cmdlet naming' {
+    It 'exports the singular function <Name>' -ForEach @(
+        @{ Name = 'Export-NhcVcpkgPort' }
+        @{ Name = 'Install-NhcVcpkgPort' }
+        @{ Name = 'Remove-NhcVcpkgPort' }
+    ) {
+        $command = Get-Command -Module $script:moduleName -Name $Name -CommandType Function -ErrorAction SilentlyContinue
+        $command | Should -Not -BeNullOrEmpty -Because 'the module must export the singular-noun cmdlet'
+    }
+
+    It 'exposes the legacy plural alias <Alias> -> <Target>' -ForEach @(
+        @{ Alias = 'Export-NhcVcpkgPorts'; Target = 'Export-NhcVcpkgPort' }
+        @{ Alias = 'Install-NhcVcpkgPorts'; Target = 'Install-NhcVcpkgPort' }
+        @{ Alias = 'Remove-NhcVcpkgPorts'; Target = 'Remove-NhcVcpkgPort' }
+    ) {
+        $resolved = Get-Command -Module $script:moduleName -Name $Alias -CommandType Alias -ErrorAction SilentlyContinue
+        $resolved | Should -Not -BeNullOrEmpty -Because 'the old plural name must remain usable as an alias'
+        $resolved.ResolvedCommand.Name | Should -Be $Target
+    }
+}

--- a/tests/Public/Export-NhcVcpkgPort.Tests.ps1
+++ b/tests/Public/Export-NhcVcpkgPort.Tests.ps1
@@ -7,7 +7,7 @@ AfterAll {
     Exit-NhcVcpkgToolsTest
 }
 
-Describe 'Export-NhcVcpkgPorts' {
+Describe 'Export-NhcVcpkgPort' {
     BeforeAll {
         function New-TestVcpkgRoot {
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test helper, not a user-facing cmdlet')]
@@ -37,13 +37,13 @@ Describe 'Export-NhcVcpkgPorts' {
         It 'returns Status false when vcpkg exits non-zero' {
             Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
 
-            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+            $result = Export-NhcVcpkgPort -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
 
             $result.Status | Should -BeFalse
         }
 
         It 'returns Status true when vcpkg exits zero' {
-            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+            $result = Export-NhcVcpkgPort -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
 
             $result.Status | Should -BeTrue
         }
@@ -51,7 +51,7 @@ Describe 'Export-NhcVcpkgPorts' {
         It 'returns Status false when vcpkg fails to launch' {
             Mock Start-Process -ModuleName $script:moduleName { throw 'launch failed' }
 
-            $result = Export-NhcVcpkgPorts -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
+            $result = Export-NhcVcpkgPort -Ports 'zlib' -Raw -Quiet -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $script:outputDir -Tag 'run'
 
             $result.Status | Should -BeFalse
         }

--- a/tests/Public/Install-NhcVcpkgPort.Tests.ps1
+++ b/tests/Public/Install-NhcVcpkgPort.Tests.ps1
@@ -7,9 +7,12 @@ AfterAll {
     Exit-NhcVcpkgToolsTest
 }
 
-Describe 'Install-NhcVcpkgPorts' {
+Describe 'Install-NhcVcpkgPort' {
     BeforeAll {
         function New-TestVcpkgRoot {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test helper, not a user-facing cmdlet')]
+            param()
+
             $rootDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
             New-Item -Path $rootDir -ItemType Directory | Out-Null
             New-Item -Path (Join-Path $rootDir '.vcpkg-root') -ItemType File | Out-Null
@@ -48,7 +51,7 @@ Describe 'Install-NhcVcpkgPorts' {
 
     Context 'Classic ports install' {
         It 'builds classic arguments with root and triplet' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $expectedRoot = (Resolve-Path -Path $script:rootInfo.RootDir).ProviderPath
             $script:capturedArguments | Should -Contain 'install'
@@ -62,7 +65,7 @@ Describe 'Install-NhcVcpkgPorts' {
 
     Context 'Manifest install arguments' {
         It 'adds manifest feature flags for -All' {
-            $null = Install-NhcVcpkgPorts -All -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Install-NhcVcpkgPort -All -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain '--feature-flags="manifest,versions"'
             $script:capturedArguments | Should -Not -Contain '--classic'
@@ -74,7 +77,7 @@ Describe 'Install-NhcVcpkgPorts' {
             $outputDir = Join-Path $TestDrive 'output'
             New-Item -Path $outputDir -ItemType Directory | Out-Null
 
-            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $outputDir -Tag 'release' |
+            $result = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OutputDir $outputDir -Tag 'release' |
             Where-Object { $_ -is [hashtable] } |
             Select-Object -Last 1
 
@@ -95,7 +98,7 @@ Describe 'Install-NhcVcpkgPorts' {
         It 'includes binary source and toggle flags' {
             $binarySources = @('files,c:/cache,readwrite', 'clear;files,d:/vcpkg,read')
 
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -BinarySources $binarySources -CachedOnly -Editable -ExactVersions
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -BinarySources $binarySources -CachedOnly -Editable -ExactVersions
 
             $script:capturedArguments | Should -Contain "--binarysource=`"$($binarySources[0])`""
             $script:capturedArguments | Should -Contain "--binarysource=`"$($binarySources[1])`""
@@ -107,7 +110,7 @@ Describe 'Install-NhcVcpkgPorts' {
 
     Context 'Environment parameters' {
         It 'passes Env hashtable entries to Start-Process -Environment' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = 'bar' }
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = 'bar' }
 
             $script:capturedEnvironment | Should -Not -BeNullOrEmpty
             $script:capturedEnvironment.ContainsKey('FOO') | Should -BeTrue
@@ -115,7 +118,7 @@ Describe 'Install-NhcVcpkgPorts' {
         }
 
         It 'passes null Env values through to Start-Process -Environment' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = $null }
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = $null }
 
             $script:capturedEnvironment | Should -Not -BeNullOrEmpty
             $script:capturedEnvironment.ContainsKey('FOO') | Should -BeTrue
@@ -127,7 +130,7 @@ Describe 'Install-NhcVcpkgPorts' {
             try {
                 $env:FOO = 'original'
 
-                $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = 'child' }
+                $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ FOO = 'child' }
 
                 $env:FOO | Should -Be 'original'
                 $script:capturedEnvironment['FOO'] | Should -Be 'child'
@@ -143,20 +146,20 @@ Describe 'Install-NhcVcpkgPorts' {
         }
 
         It 'sets VCPKG_KEEP_ENV_VARS from KeepEnvVars using semicolons' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -KeepEnvVars @('A', 'B')
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -KeepEnvVars @('A', 'B')
 
             $script:capturedEnvironment.ContainsKey('VCPKG_KEEP_ENV_VARS') | Should -BeTrue
             $script:capturedEnvironment['VCPKG_KEEP_ENV_VARS'] | Should -Be 'A;B'
         }
 
         It 'prefers KeepEnvVars over Env VCPKG_KEEP_ENV_VARS' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ VCPKG_KEEP_ENV_VARS = 'X;Y' } -KeepEnvVars @('A', 'B')
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Env @{ VCPKG_KEEP_ENV_VARS = 'X;Y' } -KeepEnvVars @('A', 'B')
 
             $script:capturedEnvironment['VCPKG_KEEP_ENV_VARS'] | Should -Be 'A;B'
         }
 
         It 'preserves KeepEnvVars entries exactly (no trim, no dedupe)' {
-            $null = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -KeepEnvVars @(' A', 'A', 'B ')
+            $null = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -KeepEnvVars @(' A', 'A', 'B ')
 
             $script:capturedEnvironment['VCPKG_KEEP_ENV_VARS'] | Should -Be ' A;A;B '
         }
@@ -166,7 +169,7 @@ Describe 'Install-NhcVcpkgPorts' {
         It 'returns Status false when vcpkg exits non-zero' {
             Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
 
-            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeFalse
         }
@@ -174,7 +177,7 @@ Describe 'Install-NhcVcpkgPorts' {
         It 'returns Status true when vcpkg exits zero' {
             Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
 
-            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeTrue
         }
@@ -182,7 +185,7 @@ Describe 'Install-NhcVcpkgPorts' {
         It 'returns Status false when vcpkg fails to launch' {
             Mock Start-Process -ModuleName $script:moduleName { throw 'launch failed' }
 
-            $result = Install-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Install-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeFalse
         }

--- a/tests/Public/Remove-NhcVcpkgPort.Tests.ps1
+++ b/tests/Public/Remove-NhcVcpkgPort.Tests.ps1
@@ -7,9 +7,12 @@ AfterAll {
     Exit-NhcVcpkgToolsTest
 }
 
-Describe 'Remove-NhcVcpkgPorts' {
+Describe 'Remove-NhcVcpkgPort' {
     BeforeAll {
         function New-TestVcpkgRoot {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test helper, not a user-facing cmdlet')]
+            param()
+
             $rootDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
             New-Item -Path $rootDir -ItemType Directory | Out-Null
             New-Item -Path (Join-Path $rootDir '.vcpkg-root') -ItemType File | Out-Null
@@ -45,41 +48,41 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'Function discoverability' {
         It 'is discoverable via Get-Command' {
-            $command = Get-Command Remove-NhcVcpkgPorts -Module NhcVcpkgTools -ErrorAction SilentlyContinue
+            $command = Get-Command Remove-NhcVcpkgPort -Module NhcVcpkgTools -ErrorAction SilentlyContinue
             $command | Should -Not -BeNullOrEmpty
-            $command.Name | Should -Be 'Remove-NhcVcpkgPorts'
+            $command.Name | Should -Be 'Remove-NhcVcpkgPort'
         }
     }
 
     Context 'Parameter sets' {
         It 'accepts -Ports parameter and passes port names to vcpkg remove' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib', 'fmt' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib', 'fmt' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain 'zlib'
             $script:capturedArguments | Should -Contain 'fmt'
         }
 
         It 'accepts -Outdated switch and passes --outdated flag to vcpkg' {
-            $null = Remove-NhcVcpkgPorts -Outdated -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Outdated -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain '--outdated'
         }
 
         It 'rejects -Ports and -Outdated used together' {
-            { Remove-NhcVcpkgPorts -Ports 'zlib' -Outdated -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command } |
+            { Remove-NhcVcpkgPort -Ports 'zlib' -Outdated -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command } |
             Should -Throw -ErrorId 'AmbiguousParameterSet*'
         }
     }
 
     Context 'Recurse switch' {
         It 'includes --recurse flag when -Recurse is specified' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -Recurse -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -Recurse -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain '--recurse'
         }
 
         It 'does not include --recurse flag when -Recurse is not specified' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Not -Contain '--recurse'
         }
@@ -87,14 +90,14 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'Common arguments' {
         It 'passes -RootDir as --vcpkg-root to vcpkg' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $expectedRoot = (Resolve-Path -Path $script:rootInfo.RootDir).ProviderPath
             $script:capturedArguments | Should -Contain "--vcpkg-root=`"$expectedRoot`""
         }
 
         It 'passes -Triplet as --triplet to vcpkg' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain "--triplet=`"$script:triplet`""
         }
@@ -103,7 +106,7 @@ Describe 'Remove-NhcVcpkgPorts' {
             $overlayPath = Join-Path $TestDrive 'overlay-ports'
             New-Item -Path $overlayPath -ItemType Directory | Out-Null
 
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OverlayPorts $overlayPath
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -OverlayPorts $overlayPath
 
             $expectedPath = (Resolve-Path -Path $overlayPath).ProviderPath
             $script:capturedArguments | Should -Contain "--overlay-ports=`"$expectedPath`""
@@ -113,7 +116,7 @@ Describe 'Remove-NhcVcpkgPorts' {
             $installPath = Join-Path $TestDrive 'custom-installed'
             New-Item -Path $installPath -ItemType Directory | Out-Null
 
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -InstallDir $installPath
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -InstallDir $installPath
 
             $expectedPath = (Resolve-Path -Path $installPath).ProviderPath
             $script:capturedArguments | Should -Contain "--x-install-root=`"$expectedPath`""
@@ -122,13 +125,13 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'ShouldProcess support' {
         It 'declares SupportsShouldProcess in CmdletBinding' {
-            $command = Get-Command Remove-NhcVcpkgPorts -Module NhcVcpkgTools
+            $command = Get-Command Remove-NhcVcpkgPort -Module NhcVcpkgTools
             $command.Parameters.ContainsKey('WhatIf') | Should -BeTrue
             $command.Parameters.ContainsKey('Confirm') | Should -BeTrue
         }
 
         It 'includes --dry-run flag when -WhatIf is specified' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -WhatIf
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -WhatIf
 
             $script:capturedArguments | Should -Contain '--dry-run'
         }
@@ -136,17 +139,17 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'Quiet switch' {
         It 'accepts -Quiet switch parameter' {
-            $command = Get-Command Remove-NhcVcpkgPorts -Module NhcVcpkgTools
+            $command = Get-Command Remove-NhcVcpkgPort -Module NhcVcpkgTools
             $quietParam = $command.Parameters['Quiet']
-            
+
             $quietParam | Should -Not -BeNullOrEmpty
             $quietParam.SwitchParameter | Should -BeTrue
         }
 
         It 'suppresses output when -Quiet is specified' {
             # Test that the -Quiet parameter can be bound and function executes
-            { Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Quiet } | Should -Not -Throw
-            
+            { Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -Quiet } | Should -Not -Throw
+
             # Verify Start-Process was called (indicating Quiet didn't prevent execution)
             $script:capturedCommand | Should -Not -BeNullOrEmpty
         }
@@ -154,7 +157,7 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'Force switch' {
         It 'accepts -Force switch parameter' {
-            $command = Get-Command Remove-NhcVcpkgPorts -Module NhcVcpkgTools
+            $command = Get-Command Remove-NhcVcpkgPort -Module NhcVcpkgTools
             $forceParam = $command.Parameters['Force']
 
             $forceParam | Should -Not -BeNullOrEmpty
@@ -166,7 +169,7 @@ Describe 'Remove-NhcVcpkgPorts' {
             $ConfirmPreference = 'Low'
 
             try {
-                $null = Remove-NhcVcpkgPorts -Ports 'zlib' -Force -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+                $null = Remove-NhcVcpkgPort -Ports 'zlib' -Force -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
                 $script:capturedCommand | Should -Not -BeNullOrEmpty
                 $script:capturedArguments | Should -Not -Contain '--dry-run'
@@ -181,7 +184,7 @@ Describe 'Remove-NhcVcpkgPorts' {
             $ConfirmPreference = 'Low'
 
             try {
-                $null = Remove-NhcVcpkgPorts -Ports 'zlib' -Force -Confirm:$false -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+                $null = Remove-NhcVcpkgPort -Ports 'zlib' -Force -Confirm:$false -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
                 $script:capturedCommand | Should -Not -BeNullOrEmpty
                 $ConfirmPreference | Should -Be 'Low'
@@ -192,7 +195,7 @@ Describe 'Remove-NhcVcpkgPorts' {
         }
 
         It 'performs dry-run when -Force and -WhatIf are both specified' {
-            $null = Remove-NhcVcpkgPorts -Ports 'zlib' -Force -WhatIf -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $null = Remove-NhcVcpkgPort -Ports 'zlib' -Force -WhatIf -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $script:capturedArguments | Should -Contain '--dry-run'
         }
@@ -202,11 +205,11 @@ Describe 'Remove-NhcVcpkgPorts' {
             $ConfirmPreference = 'Low'
 
             try {
-                $null = Remove-NhcVcpkgPorts -Ports 'zlib' -Force -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+                $null = Remove-NhcVcpkgPort -Ports 'zlib' -Force -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
                 $ConfirmPreference | Should -Be 'Low'
 
-                $command = Get-Command Remove-NhcVcpkgPorts -Module NhcVcpkgTools
+                $command = Get-Command Remove-NhcVcpkgPort -Module NhcVcpkgTools
                 $command.Definition | Should -Match 'if \(\$Force -and -not \$PSBoundParameters\.ContainsKey\(''Confirm''\)\)'
                 $command.Definition | Should -Match '\$ConfirmPreference = ''None'''
             }
@@ -218,24 +221,24 @@ Describe 'Remove-NhcVcpkgPorts' {
 
     Context 'Ports parameter validation' {
         It 'rejects empty Ports array' {
-            { Remove-NhcVcpkgPorts -Ports @() } |
+            { Remove-NhcVcpkgPort -Ports @() } |
             Should -Throw -ErrorId 'ParameterArgumentValidationError*'
         }
 
         It 'rejects null Ports value' {
-            { Remove-NhcVcpkgPorts -Ports $null } |
+            { Remove-NhcVcpkgPort -Ports $null } |
             Should -Throw -ErrorId 'ParameterArgumentValidationError*'
         }
 
         It 'accepts valid single port value' {
-            { Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet } | Should -Not -Throw
+            { Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet } | Should -Not -Throw
             $script:capturedArguments | Should -Contain 'zlib'
         }
     }
 
     Context 'Return value structure' {
         It 'returns hashtable with Command as string path' {
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result | Should -BeOfType [hashtable]
             $result.Command | Should -BeOfType [string]
@@ -243,7 +246,7 @@ Describe 'Remove-NhcVcpkgPorts' {
         }
 
         It 'returns hashtable with Arguments as array' {
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             , $result.Arguments | Should -BeOfType [array]
             $result.Arguments | Should -Contain 'zlib'
@@ -251,14 +254,14 @@ Describe 'Remove-NhcVcpkgPorts' {
         }
 
         It 'returns hashtable with RootDir as string path' {
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.RootDir | Should -BeOfType [string]
             $result.RootDir | Should -Not -BeNullOrEmpty
         }
 
         It 'returns hashtable with InstallDir containing Path and Exists keys' {
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.InstallDir | Should -BeOfType [hashtable]
             $result.InstallDir.ContainsKey('Path') | Should -BeTrue
@@ -268,7 +271,7 @@ Describe 'Remove-NhcVcpkgPorts' {
         }
 
         It 'returns Status as true on successful execution' {
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeTrue
         }
@@ -280,7 +283,7 @@ Describe 'Remove-NhcVcpkgPorts' {
             }
 
 
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -ErrorAction SilentlyContinue
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet -ErrorAction SilentlyContinue
 
             $result.Status | Should -BeFalse
         }
@@ -290,7 +293,7 @@ Describe 'Remove-NhcVcpkgPorts' {
         It 'returns Status false when vcpkg exits non-zero' {
             Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 1 } }
 
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeFalse
         }
@@ -298,7 +301,7 @@ Describe 'Remove-NhcVcpkgPorts' {
         It 'returns Status true when vcpkg exits zero' {
             Mock Start-Process -ModuleName $script:moduleName { return [pscustomobject]@{ ExitCode = 0 } }
 
-            $result = Remove-NhcVcpkgPorts -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
+            $result = Remove-NhcVcpkgPort -Ports 'zlib' -RootDir $script:rootInfo.RootDir -Command $script:rootInfo.Command -Triplet $script:triplet
 
             $result.Status | Should -BeTrue
         }

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -18,6 +18,19 @@ BeforeDiscovery {
     $mut = Get-Module -Name $script:moduleName -ListAvailable |
         Select-Object -First 1 |
             Import-Module -Force -ErrorAction Stop -PassThru
+
+    # Build test cases from the imported module's functions. Kept in the same
+    # BeforeDiscovery block as the import so $mut stays in local discovery scope
+    # (a $script:-scoped or cross-block reference is null during discovery).
+    $allModuleFunctions = & $mut { Get-Command -Module $args[0] -CommandType Function } $script:moduleName
+
+    $testCases = @()
+    foreach ($function in $allModuleFunctions)
+    {
+        $testCases += @{
+            Name = $function.Name
+        }
+    }
 }
 
 BeforeAll {
@@ -27,7 +40,7 @@ BeforeAll {
     $gitTopLevelPath = (&git rev-parse --show-toplevel)
     $gitRelatedModulePath = (($projectPath -replace [regex]::Escape([IO.Path]::DirectorySeparatorChar), '/') -replace $gitTopLevelPath, '')
     if (-not [string]::IsNullOrEmpty($gitRelatedModulePath)) { $gitRelatedModulePath = $gitRelatedModulePath.Trim('/')  + '/' }
-    $escapedGitRelatedModulePath = [regex]::Escape($gitRelatedModulePath)
+    $script:escapedGitRelatedModulePath = [regex]::Escape($gitRelatedModulePath)
 
     <#
         If the QA tests are run outside of the build script (e.g with Invoke-Pester)
@@ -41,7 +54,7 @@ BeforeAll {
 
     $script:moduleName = $ProjectName
 
-    $sourcePath = (
+    $script:sourcePath = (
         Get-ChildItem -Path $projectPath\*\*.psd1 |
             Where-Object -FilterScript {
                 ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) `
@@ -76,11 +89,11 @@ Describe 'Changelog Management' -Tag 'Changelog' {
             $headCommit = &git rev-parse HEAD
             $defaultBranchCommit = &git rev-parse origin/main
             $filesChanged += (&git @('diff', "$defaultBranchCommit...$headCommit", '--name-only') |
-                Where-Object { $_ -match "^$escapedGitRelatedModulePath" }) -replace "^$escapedGitRelatedModulePath", ""
+                Where-Object { $_ -match "^$script:escapedGitRelatedModulePath" }) -replace "^$script:escapedGitRelatedModulePath", ""
         }
 
         $filesStagedAndUnstaged = (&git @('diff', 'HEAD', '--name-only') 2>&1 |
-            Where-Object { $_ -match "^$escapedGitRelatedModulePath" }) -replace "^$escapedGitRelatedModulePath", ""
+            Where-Object { $_ -match "^$script:escapedGitRelatedModulePath" }) -replace "^$script:escapedGitRelatedModulePath", ""
 
         $filesChanged += $filesStagedAndUnstaged
 
@@ -114,26 +127,11 @@ Describe 'General module control' -Tags 'FunctionalQuality' {
     }
 }
 
-BeforeDiscovery {
-    # Must use the imported module to build test cases.
-    $allModuleFunctions = & $mut { Get-Command -Module $args[0] -CommandType Function } $script:moduleName
-
-    # Build test cases.
-    $testCases = @()
-
-    foreach ($function in $allModuleFunctions)
-    {
-        $testCases += @{
-            Name = $function.Name
-        }
-    }
-}
-
 Describe 'Quality for module' -Tags 'TestQuality' {
     BeforeDiscovery {
         if (Get-Command -Name Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)
         {
-            $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+            $script:scriptAnalyzerRules = Get-ScriptAnalyzerRule
         }
         else
         {
@@ -152,8 +150,8 @@ Describe 'Quality for module' -Tags 'TestQuality' {
         Get-ChildItem -Path 'tests\' -Recurse -Include "$Name.Tests.ps1" | Should -Not -BeNullOrEmpty
     }
 
-    It 'Should pass Script Analyzer for <Name>' -ForEach $testCases -Skip:(-not $scriptAnalyzerRules) {
-        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+    It 'Should pass Script Analyzer for <Name>' -ForEach $testCases -Skip:(-not $script:scriptAnalyzerRules) {
+        $functionFile = Get-ChildItem -Path $script:sourcePath -Recurse -Include "$Name.ps1"
 
         $pssaResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
         $report = $pssaResult | Format-Table -AutoSize | Out-String -Width 110
@@ -164,7 +162,7 @@ Describe 'Quality for module' -Tags 'TestQuality' {
 
 Describe 'Help for module' -Tags 'helpQuality' {
     It 'Should have .SYNOPSIS for <Name>' -ForEach $testCases {
-        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+        $functionFile = Get-ChildItem -Path $script:sourcePath -Recurse -Include "$Name.ps1"
 
         $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
 
@@ -183,7 +181,7 @@ Describe 'Help for module' -Tags 'helpQuality' {
     }
 
     It 'Should have a .DESCRIPTION with length greater than 40 characters for <Name>' -ForEach $testCases {
-        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+        $functionFile = Get-ChildItem -Path $script:sourcePath -Recurse -Include "$Name.ps1"
 
         $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
 
@@ -202,7 +200,7 @@ Describe 'Help for module' -Tags 'helpQuality' {
     }
 
     It 'Should have at least one (1) example for <Name>' -ForEach $testCases {
-        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+        $functionFile = Get-ChildItem -Path $script:sourcePath -Recurse -Include "$Name.ps1"
 
         $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
 
@@ -224,7 +222,7 @@ Describe 'Help for module' -Tags 'helpQuality' {
     }
 
     It 'Should have described all parameters for <Name>' -ForEach $testCases {
-        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+        $functionFile = Get-ChildItem -Path $script:sourcePath -Recurse -Include "$Name.ps1"
 
         $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
 

--- a/tests/Shared/Bootstrap-NhcVcpkgTools.ps1
+++ b/tests/Shared/Bootstrap-NhcVcpkgTools.ps1
@@ -11,6 +11,7 @@ function Invoke-BootstrapBuild {
 }
 
 function Set-ModuleUnderTest {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test bootstrap helper, not a user-facing cmdlet')]
     [CmdletBinding()]
     param(
         [string]$Name
@@ -23,6 +24,7 @@ function Set-ModuleUnderTest {
 }
 
 function Remove-ModuleUnderTest {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Test bootstrap helper, not a user-facing cmdlet')]
     [CmdletBinding()]
     param(
         [string]$Name

--- a/tests/Tools/Lint.Tests.ps1
+++ b/tests/Tools/Lint.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'lint runner' {
             $repoRoot = Join-Path -Path $TestDrive -ChildPath 'repo'
             $diagnosticPath = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/Public/Test.ps1'
 
-            Mock Get-LintTargetFiles {
+            Mock Get-LintTargetFile {
                 $diagnosticPath
             }
 
@@ -34,7 +34,7 @@ Describe 'lint runner' {
 
     Context 'exit code policy' {
         It 'returns non-zero when warnings or errors exist' {
-            Mock Get-LintTargetFiles {
+            Mock Get-LintTargetFile {
                 'NhcVcpkgTools/Public/Test.ps1'
             }
 
@@ -57,7 +57,7 @@ Describe 'lint runner' {
         }
 
         It 'returns zero when there are no findings' {
-            Mock Get-LintTargetFiles {
+            Mock Get-LintTargetFile {
                 'NhcVcpkgTools/Public/Test.ps1'
             }
 
@@ -75,7 +75,7 @@ Describe 'lint runner' {
         It 'includes only targeted directories and extensions' {
             $repoRoot = Join-Path -Path $TestDrive -ChildPath 'repo'
 
-            $targetModuleFile = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1'
+            $targetModuleFile = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/Public/Export-NhcVcpkgPort.ps1'
             $targetModuleManifest = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/NhcVcpkgTools.psd1'
             $targetTestFile = Join-Path -Path $repoRoot -ChildPath 'tests/Private/Get-Executable.Tests.ps1'
             $targetToolFile = Join-Path -Path $repoRoot -ChildPath 'tools/lint.ps1'
@@ -96,7 +96,7 @@ Describe 'lint runner' {
                 $null = New-Item -Path $file -ItemType File -Force
             }
 
-            $files = Get-LintTargetFiles -RepoRoot $repoRoot
+            $files = Get-LintTargetFile -RepoRoot $repoRoot
 
             $files | Should -Contain $targetModuleFile
             $files | Should -Contain $targetModuleManifest
@@ -111,11 +111,11 @@ Describe 'lint runner' {
     Context 'repo-relative path normalization' {
         It 'normalizes paths inside the repository to repo-relative form' {
             $repoRoot = Join-Path -Path $TestDrive -ChildPath 'repo'
-            $absolutePath = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1'
+            $absolutePath = Join-Path -Path $repoRoot -ChildPath 'NhcVcpkgTools/Public/Export-NhcVcpkgPort.ps1'
 
             $relative = Resolve-RepoRelativePath -Path $absolutePath -RepoRoot $repoRoot
 
-            $relative | Should -Be 'NhcVcpkgTools/Public/Export-NhcVcpkgPorts.ps1'
+            $relative | Should -Be 'NhcVcpkgTools/Public/Export-NhcVcpkgPort.ps1'
         }
     }
 
@@ -142,7 +142,7 @@ Describe 'lint runner' {
             $repoRoot = Join-Path -Path $TestDrive -ChildPath 'repo'
             $diagnosticPath = Join-Path -Path $repoRoot -ChildPath 'tools/lint.ps1'
 
-            Mock Get-LintTargetFiles {
+            Mock Get-LintTargetFile {
                 $diagnosticPath
             }
 

--- a/tools/lint.ps1
+++ b/tools/lint.ps1
@@ -39,8 +39,9 @@ function Resolve-RepoRelativePath {
     return $Path.Replace('\', '/')
 }
 
-function Get-LintTargetFiles {
+function Get-LintTargetFile {
     [CmdletBinding()]
+    [OutputType([string[]])]
     param(
         [Parameter(Mandatory)]
         [string]$RepoRoot
@@ -70,11 +71,12 @@ function Get-LintTargetFiles {
         }
     }
 
-    return @($collected | Sort-Object -Unique)
+    return [string[]]@($collected | Sort-Object -Unique)
 }
 
 function Format-GitHubAnnotation {
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory)]
         [psobject]$Diagnostic,
@@ -114,6 +116,7 @@ function Format-GitHubAnnotation {
 
 function Format-LocalDiagnostic {
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory)]
         [psobject]$Diagnostic,
@@ -152,7 +155,7 @@ function Invoke-LintRunner {
         [string]$RepoRoot
     )
 
-    $targetFiles = @(Get-LintTargetFiles -RepoRoot $RepoRoot)
+    $targetFiles = @(Get-LintTargetFile -RepoRoot $RepoRoot)
 
     $diagnostics = @()
     if ($targetFiles.Count -gt 0) {


### PR DESCRIPTION
## Summary

Resolves all PSScriptAnalyzer findings reported by `./tools/lint.ps1` (Warning, Error, and Information severity).

- **Singular-noun renames (`PSUseSingularNouns`)**
  - Public cmdlets `Export/Install/Remove-NhcVcpkgPorts` → `…-NhcVcpkgPort`, with the plural names retained as exported **aliases** for backward compatibility.
  - Private `Get-CommonArguments` → `Get-CommonArgument` and tooling `Get-LintTargetFiles` → `Get-LintTargetFile` (internal, no alias needed).
- **Suppressions with justification** (attribute placed inside the function before `param()`)
  - `PSAvoidUsingWriteHost` on the three cmdlets' `-WhatIf` previews (must always reach the console; `Write-Information` is silent by default).
  - `PSReviewUnusedParameter` on the Export `ArgumentCompleter` (fixed positional signature).
  - `PSUseShouldProcessForStateChangingFunctions` on test helpers `New-TestVcpkgRoot`, `Set-ModuleUnderTest`, `Remove-ModuleUnderTest`.
- **Information-level cleanups**
  - Trailing whitespace, missing `[OutputType]` on `Get-PathInfo`/`Get-TaggedOutputDir`/lint helpers, and unused-variable findings in `tests/QA/module.tests.ps1` (via `$script:` scoping + merging the two `BeforeDiscovery` blocks so `$mut` stays local).

## Test plan

- [x] `./build.ps1 -Tasks build` — succeeds, 0 errors
- [x] `./build.ps1 -Tasks test` — 133 passed, 0 failed
- [x] `./tools/lint.ps1 -Mode local` — 0 findings, exit 0
- [x] New `tests/Public/Aliases.Tests.ps1` — singular functions exported and legacy plural aliases resolve
- [x] Per-function ScriptAnalyzer QA (`TestQuality`) passes for all renamed/touched functions

## Notes

Out of scope (pre-existing, unrelated to analyzer warnings): missing unit tests for `Get-BinaryType`, `Test-EmptyDirectory`, `Get-NormalizedNamedDir`, and the absent `CHANGELOG.md`. These tags (`TestQuality`, `Changelog`) are excluded from the build pipeline.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)